### PR TITLE
feat: disable service workers for native builds using selfDestroying …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
 				"@typescript-eslint/eslint-plugin": "^8.56.1",
 				"@vitejs/plugin-vue": "^6.0.4",
 				"@vue/eslint-config-typescript": "^14.7.0",
+				"cross-env": "^7.0.3",
 				"eslint": "^10.0.2",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-prettier": "^5.5.5",
@@ -7164,6 +7165,25 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
-		"buildAndSync": "npm run build && npx cap sync",
+		"build:native": "cross-env BUILD_TARGET=native npm run build",
+		"buildAndSync": "npm run build:native && npx cap sync",
 		"preview": "vite preview",
 		"lint": "eslint . --fix --ignore-path .gitignore",
 		"generate:assets": "npx @capacitor/assets generate --iconBackgroundColor '#45b1fd' --iconBackgroundColorDark '#45b1fd' --splashBackgroundColor '#45b1fd' --splashBackgroundColorDark '#45b1fd'"
@@ -21,10 +22,10 @@
 	},
 	"dependencies": {
 		"@capacitor/android": "^8.1.0",
-		"@capacitor/ios": "^8.1.0",
 		"@capacitor/app": "^8.0.1",
 		"@capacitor/core": "^8.1.0",
 		"@capacitor/geolocation": "^8.1.0",
+		"@capacitor/ios": "^8.1.0",
 		"@capacitor/preferences": "^8.0.1",
 		"@capacitor/screen-orientation": "^8.0.1",
 		"@capacitor/share": "^8.0.1",
@@ -58,6 +59,7 @@
 		"@typescript-eslint/eslint-plugin": "^8.56.1",
 		"@vitejs/plugin-vue": "^6.0.4",
 		"@vue/eslint-config-typescript": "^14.7.0",
+		"cross-env": "^7.0.3",
 		"eslint": "^10.0.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-prettier": "^5.5.5",

--- a/src/components/UpdateToast.vue
+++ b/src/components/UpdateToast.vue
@@ -2,25 +2,33 @@
 import { IonToast, ToastButton } from '@ionic/vue';
 import { ref } from 'vue';
 import { registerSW } from 'virtual:pwa-register';
-import { Capacitor } from '@capacitor/core';
+
+// Declare the global constant injected by vite.config.ts
+declare const __BUILD_TARGET_NATIVE__: boolean;
+
+// Check if this is a native build - used for controlling update toast visibility
+const isNativeBuild = typeof __BUILD_TARGET_NATIVE__ !== 'undefined' && __BUILD_TARGET_NATIVE__;
 
 const intervalMS = 60 * 60 * 1000;
 
 const needRefresh = ref(false);
 
+// Register the service worker
+// For native builds: VitePWA is configured with selfDestroying=true, which will
+// automatically unregister any existing service workers and clear caches
+// For web builds: Normal PWA behavior with prompt-based updates
 const updateSW = registerSW({
 	onNeedRefresh() {
-		if (Capacitor.isNativePlatform()) {
-			return updateSW();
-		} else {
+		// Only show refresh prompt for web builds
+		// Native builds with selfDestroying mode won't trigger this
+		if (!isNativeBuild) {
 			needRefresh.value = true;
 		}
 	},
-	onOfflineReady() {
-		// not needed yet
-	},
+	onOfflineReady() {},
 	onRegisteredSW(swUrl, r) {
-		if (r) {
+		// Only set up periodic update checks for web builds
+		if (!isNativeBuild && r) {
 			setInterval(async () => {
 				if (r.installing || !navigator) {
 					return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,62 +7,73 @@ import { VitePWA, VitePWAOptions } from 'vite-plugin-pwa';
 import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 
+// Check if building for native platforms (Android/iOS)
+const isNativeBuild = process.env.BUILD_TARGET === 'native';
+
 const purpose = 'any maskable';
 
+// PWA options - for native builds, we use selfDestroying mode which unregisters
+// any existing service workers and doesn't create new ones
 const pwaOptions: Partial<VitePWAOptions> = {
 	mode: 'production',
 	base: '/',
 	includeAssets: ['favicon.svg'],
-	manifest: {
-		name: 'FireYak',
-		short_name: 'FireYak',
-		display: 'standalone',
-		icons: [
-			{
-				src: 'icons/icon-48.webp',
-				type: 'image/png',
-				sizes: '48x48',
-				purpose
+	// For native builds: use selfDestroying to unregister service workers
+	// For web builds: use prompt to show update notifications
+	selfDestroying: isNativeBuild,
+	registerType: isNativeBuild ? 'autoUpdate' : 'prompt',
+	// Disable manifest for native builds
+	manifest: isNativeBuild
+		? false
+		: {
+				name: 'FireYak',
+				short_name: 'FireYak',
+				display: 'standalone',
+				icons: [
+					{
+						src: 'icons/icon-48.webp',
+						type: 'image/png',
+						sizes: '48x48',
+						purpose
+					},
+					{
+						src: 'icons/icon-72.webp',
+						type: 'image/png',
+						sizes: '72x72',
+						purpose
+					},
+					{
+						src: 'icons/icon-96.webp',
+						type: 'image/png',
+						sizes: '96x96',
+						purpose
+					},
+					{
+						src: 'icons/icon-128.webp',
+						type: 'image/png',
+						sizes: '128x128',
+						purpose
+					},
+					{
+						src: 'icons/icon-192.webp',
+						type: 'image/png',
+						sizes: '192x192',
+						purpose
+					},
+					{
+						src: 'icons/icon-256.webp',
+						type: 'image/png',
+						sizes: '256x256',
+						purpose
+					},
+					{
+						src: 'icons/icon-512.webp',
+						type: 'image/png',
+						sizes: '512x512',
+						purpose
+					}
+				]
 			},
-			{
-				src: 'icons/icon-72.webp',
-				type: 'image/png',
-				sizes: '72x72',
-				purpose
-			},
-			{
-				src: 'icons/icon-96.webp',
-				type: 'image/png',
-				sizes: '96x96',
-				purpose
-			},
-			{
-				src: 'icons/icon-128.webp',
-				type: 'image/png',
-				sizes: '128x128',
-				purpose
-			},
-			{
-				src: 'icons/icon-192.webp',
-				type: 'image/png',
-				sizes: '192x192',
-				purpose
-			},
-			{
-				src: 'icons/icon-256.webp',
-				type: 'image/png',
-				sizes: '256x256',
-				purpose
-			},
-			{
-				src: 'icons/icon-512.webp',
-				type: 'image/png',
-				sizes: '512x512',
-				purpose
-			}
-		]
-	},
-	registerType: 'prompt',
 	devOptions: {
 		enabled: false,
 		/* when using generateSW the PWA plugin will switch to classic */
@@ -105,9 +116,15 @@ export default defineConfig({
 				]
 			}
 		}),
+		// Always include VitePWA plugin - for native builds it uses selfDestroying mode
+		// which unregisters service workers and clears caches
 		VitePWA(pwaOptions)
 	],
-	define: { 'process.env': {} },
+	define: {
+		'process.env': {},
+		// Expose build target to client code for conditional service worker handling
+		__BUILD_TARGET_NATIVE__: JSON.stringify(isNativeBuild)
+	},
 	resolve: {
 		alias: {
 			'@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
…mode

- Use BUILD_TARGET env variable to detect native vs web builds
- Configure VitePWA with selfDestroying mode for native builds to unregister service workers
- Disable PWA manifest for native builds
- Add __BUILD_TARGET_NATIVE__ global constant for client-side build detection
- Skip update toast prompts and periodic checks in native builds
- Preserve normal PWA behavior with update prompts for web builds