### PR TITLE
feat(map): marker path line toggle, distance cap

### DIFF
--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -578,24 +578,66 @@ watch(
 	}
 );
 
+const FIT_DEFAULT_PADDING = 16;
+// Extra clearance for the floating UI so fitted geometry (path endpoints, the
+// user dot, markers) isn't hidden under it: the address search bar spans the
+// top of the screen, and FAB columns sit along the left and right edges.
+const FIT_SEARCH_BAR_CLEARANCE = 56;
+const FIT_FAB_CLEARANCE = 72;
+// Smallest map strip (per axis) the padding may shrink the viewport to.
+const FIT_MIN_VISIBLE_PX = 80;
+
+function getFitPadding() {
+	const visibleMapView = defaultStore.visibleMapView;
+	const padding = {
+		top: visibleMapView.top + FIT_SEARCH_BAR_CLEARANCE + FIT_DEFAULT_PADDING,
+		left: visibleMapView.x + FIT_FAB_CLEARANCE,
+		bottom: visibleMapView.yMax - visibleMapView.y + FIT_DEFAULT_PADDING,
+		right: FIT_FAB_CLEARANCE
+	};
+
+	// fitBounds throws when the padding exceeds the canvas (e.g. the sheet is
+	// dragged to a high breakpoint on a small screen) — scale the padding down
+	// so a usable map strip always remains.
+	const container = rootMap?.getContainer();
+	if (container) {
+		const maxVertical = container.clientHeight - FIT_MIN_VISIBLE_PX;
+		const vertical = padding.top + padding.bottom;
+		if (vertical > maxVertical && vertical > 0) {
+			const scale = Math.max(0, maxVertical) / vertical;
+			padding.top *= scale;
+			padding.bottom *= scale;
+		}
+		const maxHorizontal = container.clientWidth - FIT_MIN_VISIBLE_PX;
+		const horizontal = padding.left + padding.right;
+		if (horizontal > maxHorizontal && horizontal > 0) {
+			const scale = Math.max(0, maxHorizontal) / horizontal;
+			padding.left *= scale;
+			padding.right *= scale;
+		}
+	}
+
+	return padding;
+}
+
 function fitMapToLayer() {
 	if (!rootMap) return;
 
-	const visibleMapView = defaultStore.visibleMapView;
-	const defaultPadding = 16;
-	const padding = {
-		top: visibleMapView.top + defaultPadding,
-		left: defaultPadding + visibleMapView.x,
-		bottom: visibleMapView.yMax - visibleMapView.y,
-		right: defaultPadding
-	};
+	const padding = getFitPadding();
 
 	if (pumpCalculation.isActive.value && pumpCalculation.hasPolyline()) {
 		const bounds = pumpCalculation.getPolylineBounds();
 		if (bounds) {
 			rootMap.fitBounds(bounds, { padding });
 		}
-	} else if (selectedPathVisible.value && selectedPathCoords.value.length >= 2) {
+	} else if (
+		// Only the nearby view frames the whole path; a selected map marker
+		// stays marker-centered (see the else branch) so dragging its sheet
+		// doesn't yank the camera out to fit the line.
+		nearbyWaterSource.isActive.value &&
+		selectedPathVisible.value &&
+		selectedPathCoords.value.length >= 2
+	) {
 		const bounds = new maplibregl.LngLatBounds();
 		selectedPathCoords.value.forEach((coord) => bounds.extend(coord as [number, number]));
 		// maxZoom keeps very short paths from zooming in to house-number level.
@@ -797,6 +839,10 @@ watch(markerFetchFailed, (failed) => {
 	}
 });
 
+// Beyond this direct (as-the-crow-flies) distance the path to a selected map
+// marker is not drawn at all.
+const MAX_PATH_DIRECT_DISTANCE_M = 2500;
+
 // Guards against stale async results: the function is fired from a watcher
 // without await, and only the newest selection may draw its path.
 let pathRequestSeq = 0;
@@ -804,6 +850,12 @@ let pathRequestSeq = 0;
 const showPathToSelectedMarker = async () => {
 	if (!selectedMarker) return;
 	const inNearbyMode = nearbyWaterSource.isActive.value;
+	// The user can turn the marker line off; the nearby view always shows it
+	// since the routed path is the point of that view.
+	if (!inNearbyMode && !settingsStore.showPathToMarker) {
+		hideSelectedPath();
+		return;
+	}
 	const requestId = ++pathRequestSeq;
 	// Outside the nearby view the map-center fallback would draw a confusing
 	// line out of the screen center, so a real user location is required there.
@@ -814,6 +866,13 @@ const showPathToSelectedMarker = async () => {
 	}
 	const markerLngLat = selectedMarker.getLngLat();
 	const target: GeoPoint = { lat: markerLngLat.lat, lng: markerLngLat.lng };
+	// A marker far from the user would draw a long, useless line across the
+	// map (and cost a routing request) — skip it. The nearby view is exempt:
+	// its results are distance-ordered and the line is its core feature.
+	if (!inNearbyMode && distanceTo(currentLocation, target) > MAX_PATH_DIRECT_DISTANCE_M) {
+		hideSelectedPath();
+		return;
+	}
 	// Prefer the routed path; fall back to the straight line.
 	const routed = await getRoutedPath(currentLocation, target, {
 		clampToRoads: settingsStore.clampHosesToRoads
@@ -827,6 +886,15 @@ const showPathToSelectedMarker = async () => {
 		fitMapToLayer();
 	}
 };
+
+// Toggling the setting while a marker is selected redraws or hides the
+// line immediately (the function no-ops when nothing is selected).
+watch(
+	() => settingsStore.showPathToMarker,
+	() => {
+		void showPathToSelectedMarker();
+	}
+);
 
 let isFirstWatch = true;
 // Watch store's selectedMarker and update map display

--- a/src/composable/settings.ts
+++ b/src/composable/settings.ts
@@ -11,6 +11,7 @@ const SHOW_ZOOM_BUTTONS_KEY = 'show_zoom_buttons';
 const MAP_LAYER_KEY = 'map_layer';
 const TERRAIN_3D_KEY = 'terrain_3d';
 const CLAMP_HOSES_TO_ROADS_KEY = 'clamp_hoses_to_roads';
+const SHOW_PATH_TO_MARKER_KEY = 'show_path_to_marker';
 const OSM_AUTH_KEY = 'osm_token';
 const MARKER_FILTERS_KEY = 'marker_filters';
 
@@ -28,6 +29,7 @@ export function useSettings() {
 			mapLayerResult,
 			terrain3dResult,
 			clampHosesToRoadsResult,
+			showPathToMarkerResult,
 			osmAuthKey,
 			markerFiltersResult
 		] = await Promise.all([
@@ -36,6 +38,7 @@ export function useSettings() {
 			Preferences.get({ key: MAP_LAYER_KEY }),
 			Preferences.get({ key: TERRAIN_3D_KEY }),
 			Preferences.get({ key: CLAMP_HOSES_TO_ROADS_KEY }),
+			Preferences.get({ key: SHOW_PATH_TO_MARKER_KEY }),
 			Preferences.get({ key: OSM_AUTH_KEY }),
 			Preferences.get({ key: MARKER_FILTERS_KEY })
 		]);
@@ -58,6 +61,10 @@ export function useSettings() {
 
 		if (clampHosesToRoadsResult.value) {
 			settingsStore.setClampHosesToRoads(clampHosesToRoadsResult.value === 'true');
+		}
+
+		if (showPathToMarkerResult.value) {
+			settingsStore.setShowPathToMarker(showPathToMarkerResult.value === 'true');
 		}
 
 		if (osmAuthKey.value) {
@@ -135,6 +142,18 @@ export function useSettings() {
 	};
 
 	/**
+	 * Saves whether the line from the user position to the selected marker is
+	 * drawn on the map (see `showPathToMarker` in the settings store).
+	 */
+	const saveShowPathToMarker = async (enabled: boolean) => {
+		settingsStore.setShowPathToMarker(enabled);
+		await Preferences.set({
+			key: SHOW_PATH_TO_MARKER_KEY,
+			value: String(enabled)
+		});
+	};
+
+	/**
 	 * Persists the OSM OAuth token and mirrors it into the settings store.
 	 */
 	const saveOsmAuthToken = async (token: string) => {
@@ -180,6 +199,7 @@ export function useSettings() {
 		saveMapLayer,
 		saveTerrain3d,
 		saveClampHosesToRoads,
+		saveShowPathToMarker,
 		saveOsmAuthToken,
 		removeOsmAuthToken,
 		getOsmAuthToken,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -355,6 +355,10 @@
 		"map": {
 			"title": "Karte",
 			"showZoomButtons": "Zoom-Buttons anzeigen",
+			"showPathToMarker": {
+				"label": "Linie zum ausgewählten Marker anzeigen",
+				"description": "Zeichnet eine Linie mit der Entfernung vom eigenen Standort zur ausgewählten Wasserentnahmestelle"
+			},
 			"clampToRoads": {
 				"label": "Schlauchweg an Straßen ausrichten",
 				"description": "Wenn deaktiviert, darf die Route durch Gärten und offenes Gelände führen (Gebäude werden immer umgangen)"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -355,6 +355,10 @@
 		"map": {
 			"title": "Map",
 			"showZoomButtons": "Show zoom buttons",
+			"showPathToMarker": {
+				"label": "Show line to selected marker",
+				"description": "Draws a line with the distance from your position to the selected water source"
+			},
 			"clampToRoads": {
 				"label": "Keep hose route on roads",
 				"description": "When off, routes may cut through gardens and open ground (buildings are always avoided)"

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -47,6 +47,9 @@ export const useSettingsStore = defineStore('settings', {
 		// When true, hose routes stick to the road network; when false (default)
 		// they may cut through gardens/open ground (buildings always avoided).
 		clampHosesToRoads: false,
+		// When true, a line from the user position to the selected marker is
+		// drawn on the map.
+		showPathToMarker: true,
 		osmAuthToken: '',
 		markerFilters: { ...DEFAULT_MARKER_FILTERS } as MarkerFilters,
 		_darkModeListener: null as ((e: MediaQueryListEvent) => void) | null
@@ -68,6 +71,9 @@ export const useSettingsStore = defineStore('settings', {
 		},
 		setClampHosesToRoads(enabled: boolean) {
 			this.clampHosesToRoads = enabled;
+		},
+		setShowPathToMarker(enabled: boolean) {
+			this.showPathToMarker = enabled;
 		},
 		setOsmAuthToken(token: string) {
 			this.osmAuthToken = token;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -50,6 +50,18 @@
 
 				<ion-item>
 					<ion-label>
+						<h2>{{ $t('settings.map.showPathToMarker.label') }}</h2>
+						<p>{{ $t('settings.map.showPathToMarker.description') }}</p>
+					</ion-label>
+					<ion-toggle
+						slot="end"
+						:checked="showPathToMarker"
+						@ion-change="onShowPathToMarkerChange($event)"
+					></ion-toggle>
+				</ion-item>
+
+				<ion-item>
+					<ion-label>
 						<h2>{{ $t('settings.map.clampToRoads.label') }}</h2>
 						<p>{{ $t('settings.map.clampToRoads.description') }}</p>
 					</ion-label>
@@ -225,8 +237,9 @@ onBeforeUnmount(() => {
 });
 
 const settingsStore = useSettingsStore();
-const { saveTheme, saveShowZoomButtons, saveClampHosesToRoads } = useSettings();
-const { theme, showZoomButtons, clampHosesToRoads } = storeToRefs(settingsStore);
+const { saveTheme, saveShowZoomButtons, saveClampHosesToRoads, saveShowPathToMarker } =
+	useSettings();
+const { theme, showZoomButtons, clampHosesToRoads, showPathToMarker } = storeToRefs(settingsStore);
 const osmAuthStore = useOsmAuthStore();
 const pendingEditsStore = usePendingEditsStore();
 const { pendingCount } = storeToRefs(pendingEditsStore);
@@ -241,6 +254,10 @@ const onShowZoomButtonsChange = (event: ToggleCustomEvent) => {
 
 const onClampToRoadsChange = (event: ToggleCustomEvent) => {
 	saveClampHosesToRoads(event.detail.checked);
+};
+
+const onShowPathToMarkerChange = (event: ToggleCustomEvent) => {
+	saveShowPathToMarker(event.detail.checked);
 };
 
 // Hose settings write straight into the pump store — it persists itself.


### PR DESCRIPTION
- Only the nearby view refits the camera to the whole path; a selected map marker stays marker-centered when the sheet is dragged
- New setting (persisted, default on) to toggle the line from the user position to the selected marker; nearby view always shows it
- Skip the line (and the routing request) when the marker is more than 2.5 km direct distance from the user
- Fit padding now clears the address search bar and FAB columns, and is clamped so fitBounds cannot exceed the canvas on small map strips