### PR TITLE
feat(water-sources): read markers from a self-hosted static OSM extract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@protomaps/basemaps": "^5.7.2",
 				"@rdlabo/ionic-theme-ios26": "^2.3.2",
 				"core-js": "^3.47.0",
+				"flatgeobuf": "^4.4.0",
 				"idb": "^8.0.3",
 				"maplibre-gl": "5.21.1",
 				"osm-api": "^4.0.0",
@@ -4022,6 +4023,13 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/@petamoriken/float16": {
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+			"integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@pkgr/core": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -4052,6 +4060,12 @@
 			"peerDependencies": {
 				"@ionic/core": ">= 8.8.1"
 			}
+		},
+		"node_modules/@repeaterjs/repeater": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+			"integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+			"license": "MIT"
 		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-rc.2",
@@ -4658,6 +4672,13 @@
 			"dependencies": {
 				"photoswipe": "*"
 			}
+		},
+		"node_modules/@types/rbush": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+			"integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -5274,6 +5295,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@zarrita/storage": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+			"integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"reference-spec-reader": "^0.2.0",
+				"unzipit": "2.0.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -7347,6 +7379,13 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7442,6 +7481,26 @@
 			},
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"node_modules/flatbuffers": {
+			"version": "25.9.23",
+			"resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+			"integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/flatgeobuf": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/flatgeobuf/-/flatgeobuf-4.4.0.tgz",
+			"integrity": "sha512-uUt1xxywP+q8K73MmyKtapF4++dMCzvoqH+ojBTsCtZBbnQEg5qy0Ujze61Rwmpmt6Ra526jpRFHtEkFun5YVw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@repeaterjs/repeater": "3.0.6",
+				"flatbuffers": "25.9.23",
+				"slice-source": "0.4.1"
+			},
+			"optionalDependencies": {
+				"ol": ">=10"
 			}
 		},
 		"node_modules/flatted": {
@@ -7581,6 +7640,39 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/geotiff": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+			"integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@petamoriken/float16": "^3.9.3",
+				"lerc": "^3.0.0",
+				"pako": "^2.0.4",
+				"parse-headers": "^2.0.2",
+				"quick-lru": "^6.1.1",
+				"web-worker": "^1.5.0",
+				"xml-utils": "^1.10.2",
+				"zstddec": "^0.2.0"
+			},
+			"engines": {
+				"node": ">=10.19"
+			}
+		},
+		"node_modules/geotiff/node_modules/quick-lru": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+			"integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -9010,6 +9102,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lerc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+			"integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+			"license": "Apache-2.0",
+			"optional": true
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10020,6 +10119,16 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/numcodecs": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+			"integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"fflate": "^0.8.0"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -10062,6 +10171,38 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/ol": {
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
+			"integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"dependencies": {
+				"@types/rbush": "4.0.0",
+				"earcut": "^3.0.0",
+				"geotiff": "^3.0.5 || ^3.1.0-beta.0",
+				"pbf": "4.0.1",
+				"rbush": "^4.0.0",
+				"zarrita": "^0.7.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/openlayers"
+			}
+		},
+		"node_modules/ol/node_modules/pbf": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"resolve-protobuf-schema": "^2.1.0"
+			},
+			"bin": {
+				"pbf": "bin/pbf"
 			}
 		},
 		"node_modules/onetime": {
@@ -10196,6 +10337,23 @@
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
+		"node_modules/pako": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+			"integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "(MIT AND Zlib)",
+			"optional": true
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10208,6 +10366,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/parse-headers": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+			"integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
@@ -10676,6 +10841,16 @@
 			"integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
 			"license": "ISC"
 		},
+		"node_modules/rbush": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+			"integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"quickselect": "^3.0.0"
+			}
+		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -10731,6 +10906,13 @@
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
+		},
+		"node_modules/reference-spec-reader": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+			"integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -11531,6 +11713,12 @@
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
+		},
+		"node_modules/slice-source": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+			"integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/smob": {
 			"version": "1.6.2",
@@ -12824,6 +13012,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/unzipit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+			"integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -13210,6 +13408,13 @@
 			"peerDependencies": {
 				"typescript": ">=5.0.0"
 			}
+		},
+		"node_modules/web-worker": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+			"integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+			"license": "Apache-2.0",
+			"optional": true
 		},
 		"node_modules/webpack-virtual-modules": {
 			"version": "0.6.2",
@@ -13738,6 +13943,13 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/xml-utils": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+			"integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+			"license": "CC0-1.0",
+			"optional": true
+		},
 		"node_modules/xml2js": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -13867,6 +14079,24 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/zarrita": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+			"integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@zarrita/storage": "^0.2.0",
+				"numcodecs": "^0.3.2"
+			}
+		},
+		"node_modules/zstddec": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+			"license": "MIT AND BSD-3-Clause",
+			"optional": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@protomaps/basemaps": "^5.7.2",
 		"@rdlabo/ionic-theme-ios26": "^2.3.2",
 		"core-js": "^3.47.0",
+		"flatgeobuf": "^4.4.0",
 		"idb": "^8.0.3",
 		"maplibre-gl": "5.21.1",
 		"osm-api": "^4.0.0",

--- a/plans/selfhost-osm-data.md
+++ b/plans/selfhost-osm-data.md
@@ -217,7 +217,9 @@ rclone config create r2 s3 provider=Cloudflare \
   access_key_id=<R2_ACCESS_KEY> secret_access_key=<R2_SECRET> \
   endpoint=https://<accountid>.r2.cloudflarestorage.com
 
-rclone copy ~/osm-data/out/ r2:fireyak-data/ \
+# Bucket `fireyak-data`, key prefix `fireyak-data/` (see §1a "Data URLs") — the
+# prefix is part of the public object URL, so the upload has to write into it.
+rclone copy ~/osm-data/out/ r2:fireyak-data/fireyak-data/ \
   --include "water_sources.fgb" \
   --include "water_sources.pmtiles" \
   --include "metadata.json" -P
@@ -230,7 +232,7 @@ riskiest assumption in the whole plan — prove it before writing app code:
 for O in https://app.fireyak.org http://localhost:5173 https://localhost capacitor://localhost; do
   echo "--- $O"
   curl -sI -H "Origin: $O" -H "Range: bytes=0-99" \
-    https://data.fireyak.org/water_sources.fgb \
+    https://data.fireyak.org/fireyak-data/water_sources.fgb \
     | grep -iE "^HTTP|access-control-allow-origin|content-range|accept-ranges"
 done
 ```
@@ -356,7 +358,7 @@ npm install flatgeobuf     # `pmtiles` deliberately NOT installed — see §4.8
 |---|---|---|
 | Marker data for viewport | **FlatGeobuf** bbox range-read | `markerHandler.updateNodeCache()` **[V]** |
 | Offline area downloads | **FlatGeobuf** bbox read | `src/offline/areaDataDownloader.ts` |
-| Single marker by id (deep link, edit-conflict check) | **Overpass** — unchanged | `fetchNodeById` stays as-is **[V]** |
+| Single marker by id (deep link, edit-conflict check) | **Overpass** | `fetchElementById(type, id)` — type-aware, so relations resolve **[V]** |
 | Live freshness | Overpass (existing code) | background-only, never blocking |
 | User's own edits | local injection | existing pending-edits queue — already solved |
 | ~~Low-zoom overview layer~~ | ~~PMTiles~~ | **descoped — see §4.8** **[V]** |
@@ -410,7 +412,11 @@ import { deserialize } from 'flatgeobuf/lib/mjs/geojson';
 import type { OverPassElement } from '@/mapHandler/overPassApi';
 import type { GeoBounds } from '@/types/geo';
 
-const BASE = import.meta.env.VITE_DATA_BASE_URL ?? 'https://data.fireyak.org';
+// Includes the `fireyak-data/` key prefix — see §1a "Data URLs". The canonical
+// object URL is `https://data.fireyak.org/fireyak-data/…`; keep this default,
+// the §2.3 CORS/range check and the pipeline's upload path in lockstep.
+const BASE =
+  import.meta.env.VITE_DATA_BASE_URL ?? 'https://data.fireyak.org/fireyak-data';
 export const FGB_URL = `${BASE}/water_sources.fgb`;
 export const META_URL = `${BASE}/metadata.json`;
 
@@ -425,6 +431,18 @@ export async function fetchWaterSources(bounds: GeoBounds): Promise<OverPassElem
   return out;
 }
 ```
+
+**Cancellation.** `deserialize()` takes no `AbortSignal`, and one bbox read is a
+*chain* of range requests (header, index, then a batch per run of nearby
+features). Breaking out of the `for await` only stops future batches — the
+request already in flight keeps downloading, which on an offline-area read is
+megabytes still arriving after the user hit Cancel. `fetchWaterSources` therefore
+takes an optional signal and, when given one, hands `deserialize` a subclassed
+`HttpRangeClient` whose `getRange` passes the signal to `fetch`. The library's
+`BufferedHttpRangeClient` accepts `string | HttpRangeClient` and forwards the
+instance to every feature batch, so the whole read becomes abortable. The
+offline-area downloader passes its per-area signal; the map's viewport read has
+nothing to cancel and omits it.
 
 `clampBounds` exists to keep Overpass inside its server timeout. A range read has
 no such limit, so on the FGB path it can be relaxed — but the padded/clamped
@@ -530,7 +548,7 @@ enumerates the work):
 | `NearbyMarker.vue:75` | `router.push(\`/nearbysources/${toRef(...)}\`)` |
 | `pumpCalculation.ts:525` | `useMarkerAsWaterSource(ref, coords)` |
 | `editQueue.ts` | `PendingEdit` keeps numeric `osmId` + `elementType` (OSM wire identity, negative temp ids) — derive refs at the call sites: `hardDeleteMapNodes([toRef(edit.elementType, edit.osmId)])`. **No `pendingEdits` migration needed.** |
-| `overPassApi.ts` | `fetchNodeById(nodeId: number)` unchanged — it queries `node(id);way(id);`; the caller attaches the ref from the returned `type` |
+| `overPassApi.ts` | `fetchElementById(type, id)` added, querying exactly the requested element type; `fetchNodeById(nodeId)` (`node(id);way(id);`) stays for the edit queue, which only has bare numeric node ids |
 
 **One behavioural fix falls out of this.** `markerImageHandler.ts:42` builds the
 Commons category `Fire-fighting-facility node-${markerId}` — a node-only
@@ -557,10 +575,22 @@ three things the chunk loop provides:
 - **Deletion reconciliation**, today guarded by
   `elements.length < OVERPASS_TRUNCATION_LIMIT` (`areaDataDownloader.ts:124`).
 
-**Implemented as:** `lastCompletedChunk` is repurposed as a 0/-1 "data phase
-done" flag (no DB migration — the field stays a `number`); the progress total
+**Implemented as:** `lastCompletedChunk` is repurposed as a "data phase done"
+flag (no DB migration — the field stays a `number`); the progress total
 becomes `DATA_PHASE_UNITS (1) + totalTilesFor(area)`, so tiles remain the bulk
 and the bar stays monotonic. `chunkBounds`/`countChunks` are deleted.
+
+The flag's "done" value is `DATA_PHASE_DONE = -2`, **not** `0`: an area
+downloaded by the old chunked code persists a chunk index, where `0` means
+"chunk 0 of N done" — a *partial* download. Had `0` been reused as the done flag,
+every such record would have looked complete, so a resume would have skipped the
+data read and left the area with a fraction of its water sources. Picking a value
+outside the legacy range (`-1` or `>= 0`) makes legacy records fall through to
+"not done" without a migration pass: the read simply runs again (it upserts, so
+repeating it is free of consequence) and the record is normalized on its first
+progress write. `isDataPhaseDone` in `databaseHandler.ts` is the single reader —
+`offlineAreasStore` and `offlineAreaActions` `downloadDetail` both go through it
+rather than comparing the raw number.
 
 Two UI call sites also assumed per-chunk semantics and had to move with it, or
 they'd have shown a stuck counter for the whole tile phase:
@@ -600,11 +630,20 @@ of being skipped whenever a chunk hit 2000 elements.
 
 ### 4.7 What stays on Overpass
 
-**Single-node reads stay on Overpass by design, and that is fine.** FGB is a
-spatial index and cannot answer "give me node 123", but `fetchNodeById`
-(`mapMarkerStore.ts:31`, `editQueue.ts:265/309/334/348`) only ever *populates or
-refreshes the cache* — deep links and edit-conflict checks read from the cache
-that the bbox range reads have already filled. No FGB replacement, no change.
+**Single-element reads stay on Overpass by design, and that is fine.** FGB is a
+spatial index and cannot answer "give me node 123", but these lookups
+(`mapMarkerStore.ts`, `editQueue.ts:265/309/334/348`) only ever *populate or
+refresh the cache* — deep links and edit-conflict checks read from the cache that
+the bbox range reads have already filled. No FGB replacement needed.
+
+The lookup does have to be **type-aware**, though. `fetchNodeById` queries
+`node(id);way(id);` only, so a relation ref (`r…`) that isn't cached — a shared
+deep link, or a cache miss after a prune — would resolve to `null` even though
+the extract publishes relation-typed ponds and tanks and the rest of the app
+treats relations as first-class. `mapMarkerStore.fetchMarkerById` therefore goes
+through `fetchElementById(parsed.type, parsed.id)`, which asks for exactly the
+type the ref names. `fetchNodeById` remains for the edit queue, whose
+`PendingEdit.osmId` is a bare numeric node id with no ref to parse.
 
 **Background freshness — implemented.** Render static data immediately; fire the
 existing Overpass query in the background; on 429/500 swallow silently. Objects

--- a/plans/selfhost-osm-data.md
+++ b/plans/selfhost-osm-data.md
@@ -557,6 +557,23 @@ three things the chunk loop provides:
 - **Deletion reconciliation**, today guarded by
   `elements.length < OVERPASS_TRUNCATION_LIMIT` (`areaDataDownloader.ts:124`).
 
+**Implemented as:** `lastCompletedChunk` is repurposed as a 0/-1 "data phase
+done" flag (no DB migration — the field stays a `number`); the progress total
+becomes `DATA_PHASE_UNITS (1) + totalTilesFor(area)`, so tiles remain the bulk
+and the bar stays monotonic. `chunkBounds`/`countChunks` are deleted.
+
+Two UI call sites also assumed per-chunk semantics and had to move with it, or
+they'd have shown a stuck counter for the whole tile phase:
+`offlineAreaActions.ts` `downloadDetail` (dropped the `{done}/{total}` counter —
+the locale keys `offlineAreas.status.loading/refreshingSources` lost those
+params) and `OfflineAreasView.vue` `estimateLine` (dropped `{chunks}` from
+`offlineAreas.add.estimate`).
+
+**Measured worst case** — a full 1° area (`MAX_AREA_SPAN_DEGREES`) over the
+dense Ruhr region: **42,956 features in 2.3 s over 21 range requests / 11.5 MB**,
+~21 MB heap. The old path needed 16 chunked Overpass calls with a 1 s sleep
+between each. No chunking is needed for size or memory reasons.
+
 The last one is a genuine **win worth stating**: an FGB read is never truncated,
 so refresh-time `reconcileDeletedNodes` becomes exact over the whole area instead
 of being skipped whenever a chunk hit 2000 elements.
@@ -645,7 +662,9 @@ new source name — a separate plan, not a phase of this one.
 
 - Fetch `metadata.json` at startup → "Data as of {planet_timestamp}". Slot:
   the Data Source card at `src/views/AboutView.vue:91-109`, after the existing
-  attribution paragraph.
+  attribution paragraph. **Implemented** as `src/composable/dataFreshness.ts`
+  (Preferences-cached, network-refreshed) + key `about.dataAsOf`
+  (`Data as of {date}` / `Datenstand: {date}`).
   **[V]** No Workbox rule matches `data.fireyak.org` (`vite.config.ts:95-167`
   covers only protomaps / ArcGIS / mapterhorn / wikimedia), so this refetches on
   every launch and fails offline — persist the timestamp via Capacitor

--- a/plans/selfhost-osm-data.md
+++ b/plans/selfhost-osm-data.md
@@ -1,0 +1,688 @@
+# FireYak Water Source Data — Implementation Plan (v3)
+
+Goal: replace Overpass as the primary read path with self-published static OSM extracts
+(fire hydrants, water tanks, suction points, fire water ponds, fire stations),
+bootstrapped on the Ubuntu laptop, rebuilt every 2 days on the Synology DS423+,
+served from Cloudflare R2 via a custom domain (CORS-enabled, free egress).
+Overpass stays as an optional best-effort freshness layer. OSM editing
+(OAuth2 + offline edit queue) is untouched.
+
+> **Why R2, not GitHub Releases (measured 2026-07-21):** release assets serve
+> range requests correctly (`302` → `206`, `accept-ranges: bytes`) BUT return no
+> `Access-Control-Allow-Origin` on either hop, and `OPTIONS` preflight 404s. A
+> `fetch()` from the app is therefore blocked by CORS — **on native as well as
+> web**, see the note below. R2 with a custom domain lets us set CORS explicitly,
+> so both builds read the same URL. GitHub Releases can stay as an optional
+> public archive.
+
+> **Native does *not* get a CORS free pass in this app.** The common claim that
+> Capacitor requests bypass browser CORS does not hold here:
+> `capacitor.config.ts:17-19` sets `CapacitorHttp: { enabled: false }`, so
+> `fetch` inside the WebView is the ordinary browser fetch. With no `server`
+> block, Capacitor's defaults put the app at origin `https://localhost`
+> (Android) and `capacitor://localhost` (iOS) — both cross-origin to
+> `data.fireyak.org`, both subject to CORS. `overPassApi.ts:320` only escapes
+> this because it calls `CapacitorHttp.post` *directly*; `flatgeobuf`'s
+> `deserialize()` drives global `fetch` internally and cannot be routed through
+> that plugin. **Consequence: the R2 CORS policy must cover the native origins
+> too** (Part 1a).
+
+```
+Laptop (one-time bootstrap)          NAS DS423+ (recurring, every 2 days)
+  planet download + first run   ──►    diff-update planet → filter → convert → upload
+                                                     │
+                                                     ▼
+                                       Cloudflare R2 bucket (fireyak-data)
+                                       water_sources.{fgb,pmtiles} + metadata.json
+                                       custom domain data.fireyak.org, CORS + CDN
+                                                     │  HTTP range requests, free egress
+                                                     ▼
+                                       FireYak app (MapLibre GL, offline:// protocol)
+                                       Overpass = optional background refresh only
+```
+
+---
+
+## Part 1 — Storage & code setup (once, ~30 min)
+
+### 1a. Cloudflare R2 bucket (the data delivery target)
+
+1. Cloudflare dashboard → R2 → **Create bucket** `fireyak-data`.
+   Free tier: 10 GB storage, free egress — your ~1.2 GB of outputs fit easily.
+2. **CORS policy** on the bucket (Settings → CORS policy) — **already configured
+   and verified 2026-07-21**:
+
+   ```json
+   [
+     {
+       "AllowedOrigins": [
+         "https://app.fireyak.org",
+         "http://localhost:5173",
+         "https://localhost",
+         "capacitor://localhost"
+       ],
+       "AllowedMethods": ["GET", "HEAD"],
+       "AllowedHeaders": ["Range", "If-Match", "If-None-Match"],
+       "ExposeHeaders": ["Content-Range", "Content-Length", "ETag", "Accept-Ranges"],
+       "MaxAgeSeconds": 86400
+     }
+   ]
+   ```
+
+   `https://localhost` is Android's origin, `capacitor://localhost` is iOS's
+   (Capacitor defaults, since `capacitor.config.ts` has no `server` block).
+   **R2 accepts the non-HTTP `capacitor://` scheme** and echoes it back in
+   `Access-Control-Allow-Origin` — measured against the dev bucket for all three
+   production origins, so the explicit allow-list is viable and no wildcard is
+   needed. Re-run the §2.3 check after any policy edit.
+3. **Custom domain** for production: R2 bucket → Settings → Public access →
+   Custom Domains → Connect `data.fireyak.org`. Needs the domain's zone in the
+   same Cloudflare account; status goes Active in a few minutes. The `r2.dev`
+   URL *does* honour the bucket CORS policy (measured), so it is fine for
+   development — but it is rate-limited by Cloudflare and explicitly not for
+   production traffic, and it gives no CDN cache control. Ship against the custom
+   domain.
+4. **API token** for uploads: R2 → Manage API Tokens → Create, **Object Read &
+   Write** scoped to this bucket. Note the Access Key ID, Secret, and the S3
+   endpoint `https://<accountid>.r2.cloudflarestorage.com`.
+
+**Data URLs** (overwriting objects keeps URLs constant):
+
+```
+# development (rate-limited, CORS works)
+https://pub-2d208d725d5849bba36ed4ed8cfb4e8e.r2.dev/water_sources.fgb
+
+# production
+https://data.fireyak.org/water_sources.pmtiles
+https://data.fireyak.org/water_sources.fgb
+https://data.fireyak.org/metadata.json
+```
+
+`BASE` in §4.3 should come from an env var (`VITE_DATA_BASE_URL`) defaulting to
+the production domain, so dev builds can point at `r2.dev` without a code change
+— and so the origin list above stays the complete set.
+
+`water_sources.pmtiles` is still produced and uploaded by the pipeline, but the
+app does **not** consume it — see §4.8. It costs nothing to keep publishing and
+leaves the door open.
+
+### 1b. Code repo (optional, for reproducibility)
+
+Create a repo `steinerjakob/fireyak-data-pipeline` (or a folder in the app repo)
+holding `Dockerfile`, `build.sh`, `export-config.json`, `README.md` so the
+pipeline is reproducible and the NAS can build the image from it. No release
+assets, no PAT with contents-write needed anymore — uploads go to R2, not GitHub.
+
+---
+
+## Part 2 — Bootstrap on the Ubuntu laptop (i7 / 32 GB / NVMe)
+
+The laptop turns the slow first iteration loop (planet download + full filter) from
+"overnight on the NAS" into "over lunch". Expected timings: filter ~20–40 min,
+export + conversions ~10 min. Total per iteration well under an hour after the
+one-time planet download.
+
+### 2.1 Run the pipeline
+
+```bash
+sudo apt install docker.io          # if not present
+git clone https://github.com/steinerjakob/fireyak-data-pipeline
+cd fireyak-data-pipeline
+docker build -t fireyak-pipeline .
+
+mkdir -p ~/osm-data                  # on the NVMe, needs ~250 GB free
+docker run --rm \
+  -v ~/osm-data:/data \
+  -e SKIP_UPLOAD=1 \
+  fireyak-pipeline
+```
+
+First run downloads `planet.osm.pbf` (~80 GB) into `~/osm-data`, then filters,
+exports, and writes `out/water_sources.{fgb,pmtiles}` + `metadata.json`.
+
+(With 32 GB RAM you could also run osmium/tippecanoe natively via apt for even
+faster iteration, but using the same Docker image as the NAS validates exactly
+what will run in production — prefer that.)
+
+### 2.2 Validate before shipping
+
+```bash
+# Schema + feature count (expect ~2–3 M features worldwide)
+ogrinfo -so -al ~/osm-data/out/water_sources.fgb
+
+# Fire ponds must come through as polygons, hydrants as points:
+ogrinfo -al ~/osm-data/out/water_sources.fgb \
+  -where "\"emergency\" = 'fire_water_pond'" | head -50
+
+# Spot-check hydrants you know (your area) against openstreetmap.org
+```
+
+Tune here if needed (tippecanoe zoom levels `-Z4 -z14`, export config), re-run —
+each iteration costs <1 h instead of a NAS night.
+
+**Confirm the FlatGeobuf has its spatial index** — this is what makes bbox range
+reads pull tight, contiguous byte ranges instead of scattered ones (big deal for
+the ~620 MB file). `build.sh` builds it with `-lco SPATIAL_INDEX=YES`; verify:
+
+```bash
+ogrinfo -so ~/osm-data/out/water_sources.fgb water_sources | grep -i index
+```
+
+If a file was built without it, rebuild just the FGB from the existing
+GeoJSONSeq (seconds–minutes) with `SPATIAL_INDEX=YES` before uploading.
+
+**Record the geometry mix per `emergency` value while you're here** — §4.4 needs
+to know which types arrive as ways/polygons rather than points, because that
+drives a required change in the app's icon/category logic:
+
+```bash
+ogrinfo -al -so ~/osm-data/out/water_sources.fgb   # geometry column type
+ogrinfo -al ~/osm-data/out/water_sources.fgb \
+  -where "\"emergency\" = 'water_tank'" | head -30
+```
+
+### 2.3 First upload to R2 (optional, from the laptop)
+
+Once satisfied you can seed R2 from the laptop so app integration can start
+before the NAS is configured. Uses `rclone` (or any S3 client) with the R2 token:
+
+```bash
+sudo apt install rclone
+rclone config create r2 s3 provider=Cloudflare \
+  access_key_id=<R2_ACCESS_KEY> secret_access_key=<R2_SECRET> \
+  endpoint=https://<accountid>.r2.cloudflarestorage.com
+
+rclone copy ~/osm-data/out/ r2:fireyak-data/ \
+  --include "water_sources.fgb" \
+  --include "water_sources.pmtiles" \
+  --include "metadata.json" -P
+```
+
+**Verify CORS + range from every origin the app will use.** This is the single
+riskiest assumption in the whole plan — prove it before writing app code:
+
+```bash
+for O in https://app.fireyak.org http://localhost:5173 https://localhost capacitor://localhost; do
+  echo "--- $O"
+  curl -sI -H "Origin: $O" -H "Range: bytes=0-99" \
+    https://data.fireyak.org/water_sources.fgb \
+    | grep -iE "^HTTP|access-control-allow-origin|content-range|accept-ranges"
+done
+```
+
+Each must show `206`, an `access-control-allow-origin` (echoing the origin or
+`*`), and a `content-range` — that is the check GitHub Releases fails. The two
+`localhost` origins are the ones people forget; they are what mobile actually
+sends.
+
+### 2.4 Hand over to the NAS
+
+```bash
+# copy planet + outputs to the NAS (gigabit LAN: ~15 min)
+rsync -ah --progress ~/osm-data/planet.osm.pbf ~/osm-data/out \
+  admin@<nas-ip>:/volume1/osm-data/
+```
+
+`pyosmium-up-to-date` reads the replication timestamp from the planet file's
+header, so the NAS continues applying daily diffs exactly where the laptop's
+download left off — no re-download, no extra state to transfer.
+
+---
+
+## Part 3 — Recurring builds on the NAS (once configured, fully hands-off)
+
+### 3.1 Folder + secrets
+
+```
+/volume1/osm-data/
+├── planet.osm.pbf   # copied from laptop, updated in place via diffs
+├── work/            # scratch, overwritten each run
+├── out/             # final artifacts
+├── env              # R2 credentials (see below)
+└── pipeline.log
+```
+
+`/volume1/osm-data/env` (chmod 600):
+
+```
+R2_ACCESS_KEY=xxxxxxxx
+R2_SECRET=xxxxxxxx
+R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+R2_BUCKET=fireyak-data
+```
+
+Keep ~250 GB free on the volume (planet + temp copy during diff apply + scratch).
+
+### 3.2 Image via Portainer
+
+Portainer → Images → Build → method "Repository" → URL of `fireyak-data-pipeline` →
+name `fireyak-pipeline`. Pipeline changes later = one-click rebuild from the repo.
+Portainer is also your log viewer and manual-trigger UI (duplicate + start the
+container for an ad-hoc rebuild).
+
+### 3.3 Schedule (DSM Task Scheduler — Portainer has no cron)
+
+Control Panel → Task Scheduler → Create → Scheduled Task → User-defined script,
+user `root`, every 2 days at 00:30:
+
+```bash
+docker run --rm \
+  --cpus="2.5" \
+  --cpu-shares=256 \
+  -v /volume1/osm-data:/data \
+  --env-file /volume1/osm-data/env \
+  fireyak-pipeline >> /volume1/osm-data/pipeline.log 2>&1
+```
+
+Task Settings → email **only on abnormal termination**.
+
+Per-run on the J4125: diff-apply ~1–2 h (rewrites the 80 GB file in place —
+normal) → filter 2–4 h → convert ~30 min → upload minutes. Total 4–6 h overnight
+(longer with the CPU cap below); lock file prevents overlaps; a failed run just
+leaves the previous R2 objects in place.
+
+### 3.4 Keep the NAS usable during a run
+
+The DS423+ has 4 cores; two flags keep it responsive while the pipeline runs:
+
+- **`--cpus="2.5"`** — hard cap: the container never uses more than 2.5 cores'
+  worth, so ~1.5 cores stay free for DSM, file access, and other containers.
+  Applies to every tool inside, including tippecanoe's threads.
+- **`--cpu-shares=256`** — soft priority (default 1024): under contention the
+  container automatically backs off and yields to interactive tasks, but still
+  uses spare capacity when the NAS is idle. This is the "polite" knob.
+
+Use both: the cap guarantees headroom, the shares make it yield gracefully.
+Tune to taste — `--cpus="3"` alone is fine if you mainly care about the
+occasional overnight access; `--cpus="2"` is the gentlest but roughly doubles
+wall-clock (still overnight). Since the job runs at 00:30, contention is usually
+minimal regardless.
+
+For disk I/O (the filter step is I/O-heavy on HDDs), optionally also lower the
+container's I/O priority by prefixing the command:
+
+```bash
+ionice -c2 -n7 nice -n 19 docker run --rm --cpus="2.5" --cpu-shares=256 \
+  -v /volume1/osm-data:/data --env-file /volume1/osm-data/env \
+  fireyak-pipeline >> /volume1/osm-data/pipeline.log 2>&1
+```
+
+(`nice`/`ionice` on the client reprioritizes reliably only if Docker doesn't
+reset priority in a fresh cgroup; the `--cpus`/`--cpu-shares` flags are the
+dependable levers, so treat `nice`/`ionice` as a bonus.)
+
+Optionally cap tippecanoe threads in `build.sh` too (`tippecanoe … -t <N>`),
+though the `--cpus` cap already bounds them.
+
+---
+
+## Part 4 — App integration (Vue 3 / MapLibre GL / Pinia / offline://)
+
+*Validated against the source 2026-07-21. Corrections that validation forced are
+marked **[V]**.*
+
+```bash
+npm install flatgeobuf     # `pmtiles` deliberately NOT installed — see §4.8
+```
+
+### 4.1 Who serves what
+
+| Use case | Source | Integration point |
+|---|---|---|
+| Marker data for viewport | **FlatGeobuf** bbox range-read | `markerHandler.updateNodeCache()` **[V]** |
+| Offline area downloads | **FlatGeobuf** bbox read | `src/offline/areaDataDownloader.ts` |
+| Single marker by id (deep link, edit-conflict check) | **Overpass** — unchanged | `fetchNodeById` stays as-is **[V]** |
+| Live freshness | Overpass (existing code) | background-only, never blocking |
+| User's own edits | local injection | existing pending-edits queue — already solved |
+| ~~Low-zoom overview layer~~ | ~~PMTiles~~ | **descoped — see §4.8** **[V]** |
+
+### 4.2 Transport: one URL, two origins **[V]**
+
+R2's CORS policy (Part 1a) is what makes the reads work — for the **web** build
+*and* the **native** builds. The frequently-repeated "Capacitor bypasses CORS"
+shortcut does not apply here: `CapacitorHttp` is disabled in
+`capacitor.config.ts:17-19`, so the WebView uses ordinary `fetch` from
+`https://localhost` (Android) / `capacitor://localhost` (iOS), and `flatgeobuf`
+drives that global `fetch` internally with no way to divert it through the
+Capacitor HTTP plugin.
+
+Practical upshot — one code path, one URL, and two obligations:
+
+- The R2 CORS policy must cover the native origins (Part 1a).
+- The Part 2.3 four-origin `curl` check is a **gate**, not a nicety. Re-run it
+  after any CORS-policy edit.
+
+No native transport shim is needed, and none should be written.
+
+### 4.3 Primary read path: FlatGeobuf at the `updateNodeCache` seam **[V]**
+
+`overPassApi.ts` is *not* the choke point for the viewport path — its
+`fetchMarkerData` has exactly one caller. The real seam is
+`src/mapHandler/markerHandler.ts:168 updateNodeCache()`, which owns the padding
+(`padBounds`, 0.25), the clamp (`clampBounds`), the tile-freshness stamps, the
+`storeMapNodes` write, `reconcileDeletedNodes`, and the `markerCacheVersion` bump.
+Swap only the fetch line inside it; everything else in that function stays.
+
+Note the data-flow consequence: `getMarkersForView` **re-reads IndexedDB**, it
+does not render the fetch's return value. So the adapter's contract is "produce
+`OverPassElement[]` and let `storeMapNodes` persist it" — not "produce GeoJSON".
+
+```ts
+// src/mapHandler/staticDataApi.ts
+import { deserialize } from 'flatgeobuf/lib/mjs/geojson';
+import type { OverPassElement } from '@/mapHandler/overPassApi';
+import type { GeoBounds } from '@/types/geo';
+
+const BASE = import.meta.env.VITE_DATA_BASE_URL ?? 'https://data.fireyak.org';
+export const FGB_URL = `${BASE}/water_sources.fgb`;
+export const META_URL = `${BASE}/metadata.json`;
+
+export async function fetchWaterSources(bounds: GeoBounds): Promise<OverPassElement[]> {
+  const out: OverPassElement[] = [];
+  for await (const f of deserialize(FGB_URL, {
+    minX: bounds.west, minY: bounds.south, maxX: bounds.east, maxY: bounds.north
+  })) {
+    const el = toOverPassElement(f as GeoJSON.Feature);
+    if (el) out.push(el);
+  }
+  return out;
+}
+```
+
+`clampBounds` exists to keep Overpass inside its server timeout. A range read has
+no such limit, so on the FGB path it can be relaxed — but the padded/clamped
+bounds are also what `markTilesFresh` and `reconcileDeletedNodes` are keyed on, so
+whatever bounds are actually read must be the ones stamped and reconciled. Keep
+them identical, exactly as the current code comment at `markerHandler.ts:170-173`
+warns.
+
+### 4.4 The adapter — mandatory, and it fixes a latent bug **[V]**
+
+FGB features carry OSM tags plus `@id` (`node/123` / `way/456`). The app keys
+everything on a **bare numeric** `id`: IndexedDB `keyPath: 'id'`
+(`databaseHandler.ts:78`), `getMapNodeById(id: number)`, `pendingEdits.osmId`, the
+`/markers/:markerId` route param. So `toOverPassElement()` must:
+
+1. **Split `@id`** into `{ id: number, type: 'node' | 'way' }` and derive the
+   namespaced key from it — see §4.5. Nodes and ways share one numeric keyspace
+   today, a collision risk the FGB makes materially worse by introducing
+   way-typed *water sources* where only fire stations are ways now. **Decision:
+   namespace the key and migrate the DB.**
+2. **Centroid polygons.** §2.2 explicitly validates that fire ponds arrive as
+   polygons, but the app stores and renders points only. `storeMapNodes`
+   (`databaseHandler.ts:136-155`) normalises `center` → `lat`/`lon` via
+   `getNodePoint`, so emitting `center: { lat, lon }` is enough.
+3. **Decide category and icon from tags, not from `type`.** ⚠️ Today
+   `markerHandler.ts:64` returns the `firestation` icon and `:89` returns the
+   `fireStation` filter key for **every** `type === 'way'`. That is safe only
+   because `overPassApi.ts:213` queries ponds/tanks as `node[…]` exclusively.
+   The moment the FGB delivers pond and tank *ways*, they render as fire stations
+   and hide under the fire-station filter. Rework `getIconKeyForNode` and
+   `categoryForNode` to branch on `tags.emergency` first, falling back to
+   `tags.amenity === 'fire_station'`.
+
+Everything downstream of `storeMapNodes` — the IndexedDB cache, nearby ranking,
+edit deep-links — then stays untouched.
+
+Bundle cost: `flatgeobuf` pulls in `flatbuffers`; budget it before merging (no
+other new dependency, `pmtiles` is descoped).
+
+### 4.5 Namespaced marker keys + DB v4 migration **[V]**
+
+Today every marker is keyed by a bare numeric `id` (`databaseHandler.ts:78`
+`keyPath: 'id'`). `node/123` and `way/123` are distinct OSM objects that would
+overwrite each other. Ships as its own commit, **before** the FGB switch, so the
+key change and the data-source change can be reverted independently.
+
+**Key format: `n<id>` / `w<id>`** (`n123`, `w456`, `n-1` for offline temp
+creates). A single opaque string — usable as an IndexedDB key, a `Map` key, a
+MapLibre feature property, and crucially a *single* URL path segment. `node/123`
+is rejected because the slash breaks `/markers/:markerId`; a compound
+`['type', id]` keyPath is rejected because it cannot appear in a URL and is
+awkward as a `Map` key.
+
+New `src/helper/osmRef.ts`:
+
+```text
+type OsmRef  = string;              // "n123" | "w456"
+type OsmType = 'node' | 'way';
+
+toRef(type: OsmType, id: number): OsmRef
+parseRef(ref: OsmRef): { type: OsmType; id: number } | null
+coerceRef(param: string): OsmRef | null   // bare number → legacy node ref
+```
+
+`coerceRef` is what keeps **already-shared links working**: `MarkerInfoHeader.vue:79`
+hands out `https://app.fireyak.org/#/markers/${id}` today, those URLs are in
+people's chat histories, and `/^-?\d+$/` must keep resolving as a node ref
+forever. New links emit `…/markers/n123`. Universal links need no change —
+`public/.well-known/apple-app-site-association` uses `paths: ["*"]`.
+
+**Migration (`FireMarker` v3 → v4).** IndexedDB cannot change a store's keyPath
+in place, so the v4 `upgrade` block creates a new store, copies, and drops the
+old one:
+
+- Create `fireMarkerRefs` with `keyPath: 'ref'` (no `autoIncrement`), and
+  recreate both existing indexes: `'lat, lon'` → `['lat', 'lon']` and
+  `'fetchedAt'`.
+- Cursor the old `fireMarker` store and write
+  `{ ...row, ref: toRef(row.type ?? 'node', row.id) }` — preserving `__deleted`
+  tombstones and `fetchedAt` (the freshness index and the startup prune both
+  depend on it). Keep `id` and `type` on the record; they are the OSM wire
+  identity that `osm-api` and `fetchNodeById` still need.
+- `db.deleteObjectStore('fireMarker')`, then point `markerStoreName` at
+  `fireMarkerRefs`.
+
+**Do not migrate by wiping the cache.** It looks disposable and is not: the
+water-source data for downloaded offline areas lives in this same store while
+`offlineAreas` still reports `status: 'ready'`. A wipe leaves areas claiming
+ready with no data — which the user discovers only once they are offline, i.e.
+exactly when it matters. The copy is a one-time cursor pass over a cache bounded
+by what the user has panned across.
+
+**Mechanical signature changes** (all compile-time-checked, so the compiler
+enumerates the work):
+
+| Location | Change |
+|---|---|
+| `databaseHandler.ts` | `CachedMapNode` gains `ref: OsmRef`; `getMapNodeById(ref)`, `deleteMapNode(ref)`, `hardDeleteMapNodes(refs)`, `getMapNodeIdsForBounds` → `getMapNodeRefsForBounds(): OsmRef[]` |
+| `markerHandler.ts:158` | `reconcileDeletedNodes` compares `toRef(e.type, e.id)` |
+| `markerHandler.ts:274-289` | GeoJSON `properties.id` → `properties.ref` |
+| `MainMap.vue:1445-1447` | push the ref; `:1641` `Number(markerId)` → `coerceRef(markerId)` |
+| `mapMarkerStore.ts` | `fetchMarkerById(ref)`, `selectMarker(ref \| null)`, `fetchPromises: Map<OsmRef, …>` |
+| `NearbyMarker.vue:75` | `router.push(\`/nearbysources/${toRef(...)}\`)` |
+| `pumpCalculation.ts:525` | `useMarkerAsWaterSource(ref, coords)` |
+| `editQueue.ts` | `PendingEdit` keeps numeric `osmId` + `elementType` (OSM wire identity, negative temp ids) — derive refs at the call sites: `hardDeleteMapNodes([toRef(edit.elementType, edit.osmId)])`. **No `pendingEdits` migration needed.** |
+| `overPassApi.ts` | `fetchNodeById(nodeId: number)` unchanged — it queries `node(id);way(id);`; the caller attaches the ref from the returned `type` |
+
+**One behavioural fix falls out of this.** `markerImageHandler.ts:42` builds the
+Commons category `Fire-fighting-facility node-${markerId}` — a node-only
+convention. Once ways are real markers, gate the image lookup on
+`parseRef(ref)?.type === 'node'` and skip it for ways, rather than querying a
+category that cannot exist.
+
+### 4.6 Offline areas: replace the Overpass chunking
+
+`areaDataDownloader.ts` currently chunks Overpass calls to stay under API limits.
+With the FGB, one bbox read returns the whole area's features — no chunking, no
+rate limits, dramatically faster offline-area downloads. Feed the results into the
+same IndexedDB structures. This also removes the last place where a user action
+directly triggers bulk Overpass load.
+
+**[V]** It is not a drop-in swap of the fetch call — `downloadAreaData` also owns
+three things the chunk loop provides:
+
+- **Resume** via `lastCompletedChunk`, persisted per chunk.
+- **Progress**: `offlineAreasStore.ts:165` computes
+  `combinedTotal = countChunks(bounds) + totalTilesFor(area)`. A single FGB read
+  collapses the data half of the bar to one unit — rework the progress model
+  rather than leaving a bar that jumps.
+- **Deletion reconciliation**, today guarded by
+  `elements.length < OVERPASS_TRUNCATION_LIMIT` (`areaDataDownloader.ts:124`).
+
+The last one is a genuine **win worth stating**: an FGB read is never truncated,
+so refresh-time `reconcileDeletedNodes` becomes exact over the whole area instead
+of being skipped whenever a chunk hit 2000 elements.
+
+### 4.7 What stays on Overpass
+
+**Single-node reads stay on Overpass by design, and that is fine.** FGB is a
+spatial index and cannot answer "give me node 123", but `fetchNodeById`
+(`mapMarkerStore.ts:31`, `editQueue.ts:265/309/334/348`) only ever *populates or
+refreshes the cache* — deep links and edit-conflict checks read from the cache
+that the bbox range reads have already filled. No FGB replacement, no change.
+
+**Background freshness (optional, phase 2).** Render static data immediately; fire
+the existing Overpass query in the background with a ~5 s timeout; on 429/500
+swallow silently. Objects missing from the Overpass response but present
+statically are **kept** (gaps ≠ deletions).
+
+**[V]** Merge at the `OverPassElement` layer before `storeMapNodes`, not on GeoJSON
+features — see §4.3. And **drop the `@version` comparison**: nothing in the app
+stores `@version` (`CachedMapNode` has no such field) and Overpass as queried
+(`out qt center 2000 tags`) omits meta entirely, so
+`Number(undefined ?? 0) >= Number(undefined ?? 0)` is always true and live always
+wins. That is the behaviour we want — express it directly rather than leaving code
+that only looks like it compares versions. A real version compare would need
+`out meta`, which is heavier for no benefit.
+
+```ts
+/** Live response wins for ids it contains; static-only ids are preserved. */
+export function mergeLive(staticEls: OverPassElement[], liveEls: OverPassElement[]) {
+  const byId = new Map(staticEls.map((e) => [e.id, e]));
+  for (const e of liveEls) byId.set(e.id, e);
+  return [...byId.values()];
+}
+```
+
+**[V]** With the static path in place the blocking-fetch failure mode effectively
+disappears, so decide what happens to `markerFetchFailed` and the toast wired at
+`MainMap.vue:836` — either retire it or repoint it at "data host unreachable and
+cache empty". Leaving it wired to a path that can no longer fail is dead UI.
+
+### 4.8 PMTiles overlay — descoped **[V]**
+
+The pipeline keeps producing `water_sources.pmtiles`, but the app does not read
+it. The original design assumed it could be routed through the existing
+`offline://` protocol and thereby inherit cache-first/offline behaviour for free.
+It cannot:
+
+- `offlineProtocol.ts:27-28` accepts exactly two URL shapes —
+  `offline://{source}/{z}/{x}/{y}` and `offline://assets/{path}`; anything else
+  throws `Bad offline URL`.
+- The handler returns `{ data: ArrayBuffer }`, never reads `params.headers`, and
+  has no way to express a `206`/partial body.
+- `tileStore.get()` returns a whole `Blob` with no byte-offset API; on native it
+  base64-decodes the entire file through Capacitor Filesystem.
+
+PMTiles would need the `pmtiles` package's own protocol doing ranged `fetch`,
+which **bypasses `offline://` entirely** — losing the cache-first behaviour that
+was the whole justification, and bypassing `tileStore`'s ref-counting and
+`sizeBytes` accounting so offline-area size/delete would not see those bytes.
+
+If low-zoom density display is ever wanted, the shape that fits this codebase is
+to pre-explode the archive into the existing tile store as `z/x/y` blobs under a
+new source name — a separate plan, not a phase of this one.
+
+### 4.9 UX & housekeeping
+
+- Fetch `metadata.json` at startup → "Data as of {planet_timestamp}". Slot:
+  the Data Source card at `src/views/AboutView.vue:91-109`, after the existing
+  attribution paragraph.
+  **[V]** No Workbox rule matches `data.fireyak.org` (`vite.config.ts:95-167`
+  covers only protomaps / ArcGIS / mapterhorn / wikimedia), so this refetches on
+  every launch and fails offline — persist the timestamp via Capacitor
+  Preferences and render the cached value. Do **not** add a Workbox rule for the
+  `.fgb` itself; range reads must not be intercepted.
+- User edits appear instantly via the existing pending-edits flow; they reach the
+  static file after the next pipeline run (≤2 days) — no UI change needed.
+- `whats-new.json` entry (both languages, user-perspective, no jargon), e.g.:
+  `{ "type": "improvement", "en": "Water sources now load reliably, even at peak times.",
+     "de": "Wasserentnahmestellen laden jetzt zuverlässig – auch zu Stoßzeiten." }`
+- Keep OSM/ODbL attribution (already present).
+
+### 4.10 Rollout order
+
+- **Phase 0 — R2 live and CORS proven** (Part 1a + the four-origin check in
+  §2.3). CORS policy is already in place; what remains is uploading real objects
+  and re-running the check against them, since an empty bucket only proves the
+  policy, not the range reads. Blocks everything else.
+- **Phase 1 — namespaced keys + DB v4** (§4.5), on **today's** Overpass data.
+  Ships and is verified on its own; no user-visible change. Keeping it separate
+  means a regression in the key migration can be reverted without also reverting
+  the data source, and vice versa.
+- **Phase 2** — `staticDataApi.ts` + adapter (§4.4, including the way/tags icon
+  fix), swapped in at `updateNodeCache`; switch `areaDataDownloader` to FGB with
+  the reworked progress model. Removes 429/500 from the viewport and offline-area
+  paths. Residual Overpass exposure: single-node reads (§4.7) — acceptable, they
+  are cache-fill only.
+- **Phase 3** — Overpass background refresh + merge, plus the
+  `markerFetchFailed` decision.
+- ~~**Phase 4** — PMTiles~~ → descoped, see §4.8.
+
+### 4.11 Interaction with the sibling plan **[V]**
+
+`plans/offline-first-water-sources.md` targets the same 429/504 problem by making
+downloaded regions the primary source and gating live fetches inside them. It
+rewrites `getMarkersForView` and touches the same downloader, so the two **will**
+conflict. Sequence them deliberately — if this plan lands first, that plan's
+gating rationale largely evaporates and it reduces to the coverage-overlay and
+onboarding pieces.
+
+### 4.12 Verification
+
+No test suite exists (AGENTS.md §7), so verification is UI-level via the repo
+`verify` skill plus `npm run lint` && `npm run build`:
+
+1. **CORS/range from all four origins** — the §2.3 `curl` gate against a real
+   uploaded object, then the same read from a web build console and a native
+   build. Riskiest assumption in the plan; prove it first.
+
+**Phase 1 (key migration) — verify before touching the data source:**
+
+1. **Upgrade path, not fresh install.** Load the app on v3 data (or check out
+   `main`, use it until markers and an offline area are cached, then switch
+   branches). After upgrade: markers still render, the offline area still reports
+   its node count, and `fireMarkerRefs` row count matches the old `fireMarker`
+   count. A fresh install proves nothing here — the copy is the risk.
+2. **Tombstones survive** — soft-delete a marker on v3, upgrade, confirm it stays
+   deleted rather than reappearing on the next fetch.
+3. **Legacy deep link** — `/#/markers/123` (bare numeric, the format already
+   shared in chats) still opens that marker; a newly shared link is `/#/markers/n123`
+   and also opens it. Test both on web and via a universal link on device.
+4. **Pending edits across the upgrade** — queue an offline edit on v3, upgrade,
+   then sync: it must still resolve to the right marker (`osmId` stays numeric;
+   only the cache lookup is re-keyed).
+
+**Phase 2 (FGB) onward:**
+
+1. **Parity** — pan over a known dense area; compare marker count and positions
+   against the Overpass build.
+2. **Way-typed sources** — confirm a fire-pond *way* renders with the `water`
+   icon and is toggled by the fire-pond filter, not the fire-station one, and
+   that a node and a way sharing the same numeric id both survive in the cache
+   (the whole point of §4.5).
+3. **Offline area** — download a small area, verify node count matches the
+   Overpass-era count, progress bar advances monotonically, and resume works
+   after a mid-download kill.
+4. **Deep link** — open a marker not yet cached; confirm the Overpass fallback
+   still fills the cache (§4.7).
+5. **Marker images** — confirm a way-typed marker skips the Commons lookup
+   instead of querying a `node-…` category (§4.5).
+6. **Offline** — airplane mode inside a downloaded area: markers render, "Data as
+   of" shows the cached timestamp, no error toast.
+
+---
+
+## Operational summary
+
+| Aspect | Value |
+|---|---|
+| Cost | €0 (laptop + NAS owned, R2 free tier: 10 GB storage, free egress) |
+| Bootstrap | laptop: planet download + <1 h per pipeline iteration |
+| Recurring | NAS: 4–6 h every 2 days (more with CPU cap), overnight, hands-off |
+| NAS load | `--cpus="2.5" --cpu-shares=256` keeps ~1.5 cores free, stays usable |
+| Serving | R2 + custom domain, CORS-enabled (incl. native origins), CDN-cached range requests — no 429 |
+| Failure mode | data a few days stale; app fully functional; email alert fires |
+| OSM courtesy | one 80 GB download ever, then ~50–100 MB diffs per run |
+| Licence | OSM/ODbL attribution (already in app) |

--- a/plans/selfhost-osm-data.md
+++ b/plans/selfhost-osm-data.md
@@ -606,10 +606,12 @@ spatial index and cannot answer "give me node 123", but `fetchNodeById`
 refreshes the cache* — deep links and edit-conflict checks read from the cache
 that the bbox range reads have already filled. No FGB replacement, no change.
 
-**Background freshness (optional, phase 2).** Render static data immediately; fire
-the existing Overpass query in the background with a ~5 s timeout; on 429/500
-swallow silently. Objects missing from the Overpass response but present
-statically are **kept** (gaps ≠ deletions).
+**Background freshness — implemented.** Render static data immediately; fire the
+existing Overpass query in the background; on 429/500 swallow silently. Objects
+missing from the Overpass response but present statically are **kept**
+(gaps ≠ deletions). This is what closes the extract's staleness window: the
+static layer guarantees the map always draws, and the live layer opportunistically
+folds in anything mapped since the extract was cut.
 
 **[V]** Merge at the `OverPassElement` layer before `storeMapNodes`, not on GeoJSON
 features — see §4.3. And **drop the `@version` comparison**: nothing in the app
@@ -620,14 +622,31 @@ wins. That is the behaviour we want — express it directly rather than leaving 
 that only looks like it compares versions. A real version compare would need
 `out meta`, which is heavier for no benefit.
 
-```ts
-/** Live response wins for ids it contains; static-only ids are preserved. */
-export function mergeLive(staticEls: OverPassElement[], liveEls: OverPassElement[]) {
-  const byId = new Map(staticEls.map((e) => [e.id, e]));
-  for (const e of liveEls) byId.set(e.id, e);
-  return [...byId.values()];
-}
-```
+**Implemented as `refreshFromLiveSource()` in `markerHandler.ts`, and no explicit
+merge step is needed at all.** IndexedDB *is* the merge point: `storeMapNodes`
+keys by ref and overwrites, so a live result simply wins for the ids it contains
+while static-only ids stay put. The standalone `mergeLive` helper this plan
+sketched would have been dead code.
+
+Called fire-and-forget from `getMarkersForView` on every map movement, layered on
+top of whichever static branch ran. Design points worth keeping:
+
+- **Its own freshness registry** (`liveFreshness`, 5-min TTL), separate from the
+  static `tileFreshness` (15-min). They answer different questions and must not
+  satisfy each other. Combined with the existing 0.05° bbox snapping, small pans
+  collapse onto the same key and issue no new request.
+- **Upsert only, never reconcile.** Overpass truncates at 2000 elements and can
+  answer partially, so absence is not deletion. `storeMapNodes` preserving the
+  `__deleted` tombstone is what stops a live refresh resurrecting a marker the
+  user deleted locally.
+- **No client-side timeout**, despite the ~5 s above. Nothing waits on this, and
+  aborting an Overpass query does not refund its rate-limit slot — cutting it off
+  would discard a result already paid for. `overPassApi`'s own per-attempt
+  timeouts, instance pool and 429 cool-downs are the right controls.
+- **Skipped while offline**, so it doesn't log failures for no reason.
+- Order matters: stamp `liveFreshness` *before* bumping `markerCacheVersion`.
+  `MainMap` watches that ref by re-calling `getMarkersForView`, so stamping later
+  would re-enter and loop — the same trap as §4.3's empty-area bug.
 
 **[V]** With the static path in place the blocking-fetch failure mode effectively
 disappears, so decide what happens to `markerFetchFailed` and the toast wired at

--- a/plans/selfhost-osm-data.md
+++ b/plans/selfhost-osm-data.md
@@ -89,18 +89,25 @@ Laptop (one-time bootstrap)          NAS DS423+ (recurring, every 2 days)
 **Data URLs** (overwriting objects keeps URLs constant):
 
 ```
-# development (rate-limited, CORS works)
-https://pub-2d208d725d5849bba36ed4ed8cfb4e8e.r2.dev/water_sources.fgb
+# production — live and CORS-verified 2026-07-21
+https://data.fireyak.org/fireyak-data/water_sources.fgb        # 617 MB
+https://data.fireyak.org/fireyak-data/water_sources.pmtiles    # 571 MB
+https://data.fireyak.org/fireyak-data/metadata.json
 
-# production
-https://data.fireyak.org/water_sources.pmtiles
-https://data.fireyak.org/water_sources.fgb
-https://data.fireyak.org/metadata.json
+# same objects via the dev URL (rate-limited, CORS also works)
+https://pub-2d208d725d5849bba36ed4ed8cfb4e8e.r2.dev/fireyak-data/…
 ```
 
-`BASE` in §4.3 should come from an env var (`VITE_DATA_BASE_URL`) defaulting to
-the production domain, so dev builds can point at `r2.dev` without a code change
-— and so the origin list above stays the complete set.
+Note the `fireyak-data/` **key prefix** — the upload placed the objects in a
+folder inside the bucket, so it is part of the URL. `BASE` therefore includes it.
+
+Gate result (§2.3), all three origins: `206` + `content-range` +
+`access-control-allow-origin` echoing the origin, including
+`capacitor://localhost`. Phase 0 is **done**.
+
+`BASE` in §4.3 comes from an env var (`VITE_DATA_BASE_URL`) defaulting to the
+production URL, so dev builds can point elsewhere without a code change — and so
+the origin list above stays the complete set.
 
 `water_sources.pmtiles` is still produced and uploaded by the pipeline, but the
 app does **not** consume it — see §4.8. It costs nothing to keep publishing and
@@ -170,6 +177,24 @@ ogrinfo -so ~/osm-data/out/water_sources.fgb water_sources | grep -i index
 
 If a file was built without it, rebuild just the FGB from the existing
 GeoJSONSeq (seconds–minutes) with `SPATIAL_INDEX=YES` before uploading.
+
+> ⚠️ **The export MUST carry the OSM element type — the first upload did not.**
+> Measured on the 2026-07-21 file: `@id` is a bare `Integer64` (e.g.
+> `6915617458`) with no type, and the `osm_type` column is empty on every
+> feature (it exists in the schema only because some OSM object somewhere
+> carries a literal `osm_type` *tag*). Without the type, `node/123` and
+> `way/123` cannot be told apart, which is exactly what the app's namespaced
+> keys (§4.5) need.
+>
+> Fix in `build.sh`: add **`--add-unique-id=type_id`** to the `osmium export`
+> invocation, so `@id` becomes the string `"n123"` / `"w456"` / `"r789"`.
+> Confirm the exact flag against `osmium export --help` on the build machine.
+> Then re-run and re-upload. Note this also introduces **relations** (`r`) —
+> `amenity=fire_station` multipolygons — which is why `OsmRef` supports them.
+>
+> Until that file lands, `staticDataApi.ts` falls back to inferring the type
+> from geometry (`Point` → node, else way) and warns once per session. That
+> fallback is transitional and should be deleted once the typed export is live.
 
 **Record the geometry mix per `emergency` value while you're here** — §4.4 needs
 to know which types arrive as ways/polygons rather than points, because that
@@ -367,6 +392,18 @@ Note the data-flow consequence: `getMarkersForView` **re-reads IndexedDB**, it
 does not render the fetch's return value. So the adapter's contract is "produce
 `OverPassElement[]` and let `storeMapNodes` persist it" — not "produce GeoJSON".
 
+> ⚠️ **Move the freshness check out of the cache-hit branch.** `getMarkersForView`
+> only consulted `areTilesFresh` when the cache already had markers; an empty
+> cache fetched unconditionally. An area with genuinely **no** water sources
+> caches nothing, so that condition never stops being true — and because
+> `updateNodeCache` bumps `markerCacheVersion`, which `MainMap.vue:546` watches
+> by calling `getMarkersForView` again, it is an **infinite fetch loop**, not
+> merely redundant polling. Observed in practice.
+>
+> The freshness registry is the only record that we already asked about an area
+> and the answer was "none here", so it must gate both branches. Compute
+> `areTilesFresh` once, before the empty/populated split, and use it in each.
+
 ```ts
 // src/mapHandler/staticDataApi.ts
 import { deserialize } from 'flatgeobuf/lib/mjs/geojson';
@@ -523,6 +560,26 @@ three things the chunk loop provides:
 The last one is a genuine **win worth stating**: an FGB read is never truncated,
 so refresh-time `reconcileDeletedNodes` becomes exact over the whole area instead
 of being skipped whenever a chunk hit 2000 elements.
+
+> ⚠️ **Correction to the above — reconciliation needs a staleness guard, not
+> just the dropped truncation guard.** This plan previously said the FGB path
+> could "reconcile unconditionally". That is wrong and would delete live data.
+> The extract is rebuilt every ~2 days (the file live on 2026-07-21 had a planet
+> timestamp of 2026-07-12 — a 9-day window), so it knows nothing about anything
+> mapped since it was cut. Reconciling against it would hard-delete every marker
+> newer than the extract from the local cache — **including the marker the user
+> just added through the app**, on their very next pan.
+>
+> Rule implemented instead: delete a cached node the extract doesn't mention
+> **only if `fetchedAt < planet_timestamp`** — i.e. only if our knowledge of it
+> predates the extract. Anything we learned after the cut is kept, since the
+> extract cannot be authoritative about it. This protects user edits, offline
+> temp creates, and `fetchNodeById` results, while still removing genuinely
+> deleted objects once a later rebuild advances past when we cached them.
+> `reconcileDeletedNodes` takes an optional `sourceTimestampMs`; omit it for a
+> live source like Overpass, where absence really does mean deletion. If the
+> timestamp can't be determined, skip reconciliation entirely — the TTL prune is
+> the safe backstop.
 
 ### 4.7 What stays on Overpass
 

--- a/src/assets/whats-new.json
+++ b/src/assets/whats-new.json
@@ -1,5 +1,11 @@
 {
-	"unreleased": [],
+	"unreleased": [
+		{
+			"type": "improvement",
+			"en": "Water sources now load reliably and much faster, even at peak times.",
+			"de": "Wasserentnahmestellen laden jetzt zuverlässig und deutlich schneller – auch zu Stoßzeiten."
+		}
+	],
 	"releases": [
 		{
 			"version": "2.16.0",

--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -184,6 +184,7 @@ import { usePumpCalculationStore } from '@/store/pumpCalculationSettings';
 import { outdoorsFlavor } from '@/map/outdoorsFlavor';
 import { nightFlavor } from '@/map/nightFlavor';
 import { satelliteFlavor } from '@/map/satelliteFlavor';
+import { coerceRef } from '@/helper/osmRef';
 
 const MAP_ELEMENT_ID = 'map';
 const MOVE_DEBOUNCE_MS = 300;
@@ -1431,10 +1432,10 @@ function setupMapEventListeners(map: maplibregl.Map) {
 			// source offers it as the suction point (hydrant pressure and all)
 			// instead of navigating to the marker.
 			if (route.path.includes('supplypipe')) {
-				const tappedId = feature.properties?.id;
-				if (tappedId) {
+				const tappedRef = feature.properties?.ref;
+				if (tappedRef) {
 					const coords = (feature.geometry as GeoJSON.Point).coordinates as [number, number];
-					pumpCalculation.useMarkerAsWaterSource(Number(tappedId), {
+					pumpCalculation.useMarkerAsWaterSource(tappedRef, {
 						lat: coords[1],
 						lng: coords[0]
 					});
@@ -1442,9 +1443,9 @@ function setupMapEventListeners(map: maplibregl.Map) {
 				return;
 			}
 
-			const markerId = feature.properties?.id;
-			if (markerId) {
-				router.push(`/markers/${markerId}`);
+			const markerRef = feature.properties?.ref;
+			if (markerRef) {
+				router.push(`/markers/${markerRef}`);
 			}
 			return;
 		}
@@ -1638,8 +1639,9 @@ onMounted(async () => {
 	watch(
 		() => route.params.markerId,
 		async (markerId) => {
-			const markerIdNumber = markerId ? Number(markerId) : null;
-			await markerStore.selectMarker(markerIdNumber);
+			const param = Array.isArray(markerId) ? markerId[0] : markerId;
+			const ref = param ? coerceRef(param) : null;
+			await markerStore.selectMarker(ref);
 		},
 		{ immediate: true }
 	);

--- a/src/components/MarkerInfoHeader.vue
+++ b/src/components/MarkerInfoHeader.vue
@@ -75,8 +75,8 @@ const openNavigation = () => {
 const shareMarker = async () => {
 	if (!markerData.value) return;
 
-	const markerId = markerData.value.id;
-	const url = `https://app.fireyak.org/#/markers/${markerId}`;
+	const markerRef = markerData.value.ref;
+	const url = `https://app.fireyak.org/#/markers/${markerRef}`;
 	const title = getTitle();
 
 	try {
@@ -105,11 +105,7 @@ const shareMarker = async () => {
 		<ion-toolbar class="ios26-disabled">
 			<ion-title>{{ getTitle() }}</ion-title>
 			<ion-buttons slot="end">
-				<ion-button
-					v-if="editAllowed"
-					@click="startEdit"
-					:title="t('markerEdit.title.edit')"
-				>
+				<ion-button v-if="editAllowed" @click="startEdit" :title="t('markerEdit.title.edit')">
 					<ion-icon :icon="createOutline" />
 				</ion-button>
 				<ion-button @click="shareMarker" :title="t('markerInfo.share.title')">

--- a/src/components/NearbyMarker.vue
+++ b/src/components/NearbyMarker.vue
@@ -7,6 +7,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { OverPassElement } from '@/mapHandler/overPassApi';
 import { useI18n } from 'vue-i18n';
 import { usePumpCalculationStore } from '@/store/pumpCalculationSettings';
+import { coerceRef, toRef } from '@/helper/osmRef';
 
 const { list } = useNearbyWaterSource();
 const router = useRouter();
@@ -53,7 +54,7 @@ const formattedList = computed(() => {
 		// the hoses actually have to cover (and what the B-tube count is for).
 		const displayDistance = nearbyMarker.routedDistance ?? nearbyMarker.distance;
 		return {
-			id: nearbyMarker.element.id,
+			ref: toRef(nearbyMarker.element.type, nearbyMarker.element.id),
 			title: getTitle(nearbyMarker.element),
 			icon: nearbyMarker.icon,
 			distance: nearbyMarker.distance,
@@ -62,7 +63,15 @@ const formattedList = computed(() => {
 	});
 });
 
-const selectedMarkerId = computed(() => route.params.markerId || null);
+// Coerced, not compared raw: a legacy shared link still routes here as a bare
+// number (`/nearbysources/123`), which would never match the `n123` refs the
+// list items now carry.
+const selectedMarkerRef = computed(() => {
+	const param = Array.isArray(route.params.markerId)
+		? route.params.markerId[0]
+		: route.params.markerId;
+	return param ? coerceRef(param) : null;
+});
 </script>
 
 <template>
@@ -70,10 +79,10 @@ const selectedMarkerId = computed(() => route.params.markerId || null);
 		<!-- Nearby Water Sources -->
 		<ion-item
 			v-for="item in formattedList"
-			:key="item.id"
+			:key="item.ref"
 			button
-			@click="router.push(`/nearbysources/${item.id}`)"
-			:class="{ selected: selectedMarkerId === String(item.id) }"
+			@click="router.push(`/nearbysources/${item.ref}`)"
+			:class="{ selected: selectedMarkerRef === item.ref }"
 		>
 			<img slot="start" :src="item.icon" style="height: 24px" alt="Target marker" />
 			<ion-label>

--- a/src/composable/dataFreshness.ts
+++ b/src/composable/dataFreshness.ts
@@ -1,0 +1,75 @@
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Preferences } from '@capacitor/preferences';
+import { getDataMetadata } from '@/mapHandler/staticDataApi';
+
+const PLANET_TIMESTAMP_KEY = 'data_planet_timestamp';
+
+/**
+ * ISO planet timestamp of the static water-source extract currently in use, or
+ * `null` while unknown. Module-level so every view shares one value and the
+ * network lookup happens once per session.
+ */
+const planetTimestamp = ref<string | null>(null);
+let loaded = false;
+
+/**
+ * Freshness of the self-published OSM extract ("Data as of …", §4.9).
+ *
+ * The value is persisted via Capacitor Preferences and rendered from that cache
+ * first: the app is offline-capable and no Workbox rule covers the data host, so
+ * a network read would otherwise leave the line blank exactly when a user is
+ * offline and most wants to know how current their data is.
+ */
+export function useDataFreshness() {
+	const { locale } = useI18n();
+
+	/** Reads the cached value, then refreshes it from the network in the background. */
+	async function load(): Promise<void> {
+		if (loaded) return;
+
+		try {
+			const cached = await Preferences.get({ key: PLANET_TIMESTAMP_KEY });
+			if (cached.value) planetTimestamp.value = cached.value;
+		} catch {
+			// Preferences unavailable — fall through to the network lookup.
+		}
+
+		const meta = await getDataMetadata();
+		// Only latch on success, so a lookup that failed while offline is retried
+		// the next time the user opens this view rather than staying stale for the
+		// rest of the session.
+		if (!meta?.planet_timestamp) return;
+		loaded = true;
+
+		planetTimestamp.value = meta.planet_timestamp;
+		try {
+			await Preferences.set({ key: PLANET_TIMESTAMP_KEY, value: meta.planet_timestamp });
+		} catch {
+			// Non-fatal: the value still renders for this session.
+		}
+	}
+
+	/**
+	 * Localised date, or `null` when the timestamp is unknown or unparseable.
+	 *
+	 * Rendered in **UTC**, not local time. The planet timestamp is the instant
+	 * the OSM extract was cut and typically lands seconds before midnight UTC
+	 * (e.g. `2026-07-12T23:59:57Z`), so formatting it locally would roll the
+	 * date forward a day for every user east of UTC — making the data look one
+	 * day fresher than it is.
+	 */
+	function formatted(): string | null {
+		if (!planetTimestamp.value) return null;
+		const parsed = Date.parse(planetTimestamp.value);
+		if (Number.isNaN(parsed)) return null;
+		return new Date(parsed).toLocaleDateString(locale.value || 'en', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			timeZone: 'UTC'
+		});
+	}
+
+	return { planetTimestamp, load, formatted };
+}

--- a/src/composable/offlineAreaActions.ts
+++ b/src/composable/offlineAreaActions.ts
@@ -1,7 +1,6 @@
 import { alertController, toastController } from '@ionic/vue';
 import { useI18n } from 'vue-i18n';
 import { useOfflineAreasStore } from '@/store/offlineAreasStore';
-import { countChunks } from '@/offline/areaDataDownloader';
 import {
 	tileCount,
 	PROTOMAPS_MAX_ZOOM,
@@ -67,26 +66,23 @@ export function useOfflineAreaActions() {
 	}
 
 	/**
-	 * Progress text for an in-flight download. Water-source (Overpass) data and
-	 * tiles run in parallel, so this shows the overall tile-inclusive percentage
-	 * and, while the water-source fetch is still pending, a chunk counter for it
-	 * (each chunk is one long-running Overpass call).
+	 * Progress text for an in-flight download. Water-source data and tiles run in
+	 * parallel, so this shows the overall tile-inclusive percentage plus, while
+	 * the water-source read is still pending, a line for it.
+	 *
+	 * The data phase is a single FlatGeobuf bbox read (§4.6), so there is no
+	 * counter to show any more — `lastCompletedChunk` is now just a done flag
+	 * (`-1` pending, `0` done), not a chunk index.
 	 */
 	function downloadDetail(area: OfflineArea, refreshing: boolean): string {
 		const parts: string[] = [];
 
-		// Water-source fetch is still running while not every chunk is completed.
-		const chunkTotal = countChunks(area.bounds);
-		const chunksDone = area.lastCompletedChunk + 1;
-		if (chunksDone < chunkTotal) {
-			// While chunk i is in flight, lastCompletedChunk is i-1 → 1-based i+1.
-			const current = Math.min(chunksDone + 1, chunkTotal);
+		if (area.lastCompletedChunk < 0) {
 			parts.push(
 				t(
 					refreshing
 						? 'offlineAreas.status.refreshingSources'
-						: 'offlineAreas.status.loadingSources',
-					{ done: current, total: chunkTotal }
+						: 'offlineAreas.status.loadingSources'
 				)
 			);
 		}

--- a/src/composable/offlineAreaActions.ts
+++ b/src/composable/offlineAreaActions.ts
@@ -8,7 +8,7 @@ import {
 	TERRAIN_MAX_ZOOM
 } from '@/offline/tileMath';
 import type { GeoBounds } from '@/types/geo';
-import type { OfflineArea } from '@/mapHandler/databaseHandler';
+import { isDataPhaseDone, type OfflineArea } from '@/mapHandler/databaseHandler';
 
 /**
  * Calibration constants for pre-download size estimates. Average compressed
@@ -71,13 +71,15 @@ export function useOfflineAreaActions() {
 	 * the water-source read is still pending, a line for it.
 	 *
 	 * The data phase is a single FlatGeobuf bbox read (§4.6), so there is no
-	 * counter to show any more — `lastCompletedChunk` is now just a done flag
-	 * (`-1` pending, `0` done), not a chunk index.
+	 * counter to show any more — `lastCompletedChunk` is now just a done flag,
+	 * not a chunk index. Read it through `isDataPhaseDone` so a legacy chunk
+	 * index on a record from the old chunked downloader isn't mistaken for
+	 * "sources already loaded" while the data read is in fact still running.
 	 */
 	function downloadDetail(area: OfflineArea, refreshing: boolean): string {
 		const parts: string[] = [];
 
-		if (area.lastCompletedChunk < 0) {
+		if (!isDataPhaseDone(area)) {
 			parts.push(
 				t(
 					refreshing

--- a/src/composable/pumpCalculation.ts
+++ b/src/composable/pumpCalculation.ts
@@ -15,6 +15,7 @@ import { getRoutedPath } from '@/mapHandler/nearbyRouting';
 import { getMapNodeById } from '@/mapHandler/databaseHandler';
 import { alertController } from '@ionic/vue';
 import { GeoPoint, distanceTo } from '@/types/geo';
+import { OsmRef } from '@/helper/osmRef';
 
 const PUMP_LINE_SOURCE = 'pump-line';
 const PUMP_LINE_LAYER = 'pump-line-layer';
@@ -522,8 +523,8 @@ export function usePumpCalculation() {
 	 * `fire_hydrant:pressure` tag becomes the line's starting pressure (no
 	 * pump at the source); otherwise a source pump is still assumed.
 	 */
-	const useMarkerAsWaterSource = async (markerId: number, coords: GeoPoint) => {
-		const node = await getMapNodeById(markerId);
+	const useMarkerAsWaterSource = async (ref: OsmRef, coords: GeoPoint) => {
+		const node = await getMapNodeById(ref);
 		const emergency = node?.tags?.emergency;
 		const isWaterSource =
 			emergency === 'fire_hydrant' ||

--- a/src/helper/osmRef.ts
+++ b/src/helper/osmRef.ts
@@ -1,0 +1,66 @@
+/**
+ * Namespaced marker keys (§4.5 of `plans/selfhost-osm-data.md`).
+ *
+ * Today every marker is keyed by a bare numeric OSM id. `node/123` and
+ * `way/123` are distinct OSM objects that would otherwise overwrite each
+ * other in the IndexedDB cache, in a `Map`, and as a MapLibre feature
+ * property. An {@link OsmRef} is a single opaque string (`n123`, `w456`,
+ * `n-1` for an offline temp create) that works as all three — and crucially
+ * as a *single* URL path segment for `/markers/:markerId`.
+ */
+
+/** A namespaced OSM element key: `"n123"` (node) or `"w456"` (way). */
+export type OsmRef = string;
+
+/** The two OSM element types FireYak deals with. */
+export type OsmType = 'node' | 'way';
+
+/** Maps an {@link OsmType} to its {@link OsmRef} prefix letter. */
+const REF_PREFIX: Record<OsmType, string> = {
+	node: 'n',
+	way: 'w'
+};
+
+const REF_TYPE_BY_PREFIX: Record<string, OsmType> = {
+	n: 'node',
+	w: 'way'
+};
+
+/**
+ * Builds the namespaced ref for an OSM element. `type` is typed loosely
+ * (`OsmType | string`) because callers often hand in an {@link OverPassElement}
+ * whose `type` field is a plain `string`; anything other than `'way'` is
+ * treated as `'node'`, matching the rest of the codebase's node-first defaults.
+ */
+export function toRef(type: OsmType | string, id: number): OsmRef {
+	const prefix = type === 'way' ? REF_PREFIX.way : REF_PREFIX.node;
+	return `${prefix}${id}`;
+}
+
+/**
+ * Parses a namespaced ref back into its type and numeric id. Returns `null`
+ * for anything that isn't a valid `n<id>` / `w<id>` ref (including bare
+ * numbers — use {@link coerceRef} to accept those).
+ */
+export function parseRef(ref: OsmRef): { type: OsmType; id: number } | null {
+	const match = /^([nw])(-?\d+)$/.exec(ref);
+	if (!match) return null;
+	return { type: REF_TYPE_BY_PREFIX[match[1]], id: Number(match[2]) };
+}
+
+/**
+ * Coerces a route/query param into an {@link OsmRef}, accepting both the
+ * current `n123` / `w456` format and a bare number.
+ *
+ * The bare-number case is load-bearing, not legacy cruft to clean up: shared
+ * links of the form `https://app.fireyak.org/#/markers/123` are already sitting
+ * in users' chat histories, and `/^-?\d+$/` must keep resolving as a node ref
+ * forever — new links emit `…/markers/n123`, but old ones must never 404.
+ *
+ * Returns `null` for garbage input.
+ */
+export function coerceRef(param: string): OsmRef | null {
+	if (parseRef(param) !== null) return param;
+	if (/^-?\d+$/.test(param)) return toRef('node', Number(param));
+	return null;
+}

--- a/src/helper/osmRef.ts
+++ b/src/helper/osmRef.ts
@@ -9,41 +9,43 @@
  * as a *single* URL path segment for `/markers/:markerId`.
  */
 
-/** A namespaced OSM element key: `"n123"` (node) or `"w456"` (way). */
+/** A namespaced OSM element key: `"n123"` (node), `"w456"` (way) or `"r789"` (relation). */
 export type OsmRef = string;
 
-/** The two OSM element types FireYak deals with. */
-export type OsmType = 'node' | 'way';
+/** The OSM element types FireYak deals with. */
+export type OsmType = 'node' | 'way' | 'relation';
 
 /** Maps an {@link OsmType} to its {@link OsmRef} prefix letter. */
 const REF_PREFIX: Record<OsmType, string> = {
 	node: 'n',
-	way: 'w'
+	way: 'w',
+	relation: 'r'
 };
 
 const REF_TYPE_BY_PREFIX: Record<string, OsmType> = {
 	n: 'node',
-	w: 'way'
+	w: 'way',
+	r: 'relation'
 };
 
 /**
  * Builds the namespaced ref for an OSM element. `type` is typed loosely
  * (`OsmType | string`) because callers often hand in an {@link OverPassElement}
- * whose `type` field is a plain `string`; anything other than `'way'` is
- * treated as `'node'`, matching the rest of the codebase's node-first defaults.
+ * whose `type` field is a plain `string`; anything not recognised falls back to
+ * `'node'`, matching the rest of the codebase's node-first defaults.
  */
 export function toRef(type: OsmType | string, id: number): OsmRef {
-	const prefix = type === 'way' ? REF_PREFIX.way : REF_PREFIX.node;
+	const prefix = REF_PREFIX[type as OsmType] ?? REF_PREFIX.node;
 	return `${prefix}${id}`;
 }
 
 /**
  * Parses a namespaced ref back into its type and numeric id. Returns `null`
- * for anything that isn't a valid `n<id>` / `w<id>` ref (including bare
- * numbers — use {@link coerceRef} to accept those).
+ * for anything that isn't a valid `n<id>` / `w<id>` / `r<id>` ref (including
+ * bare numbers — use {@link coerceRef} to accept those).
  */
 export function parseRef(ref: OsmRef): { type: OsmType; id: number } | null {
-	const match = /^([nw])(-?\d+)$/.exec(ref);
+	const match = /^([nwr])(-?\d+)$/.exec(ref);
 	if (!match) return null;
 	return { type: REF_TYPE_BY_PREFIX[match[1]], id: Number(match[2]) };
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -128,6 +128,7 @@
 		"openInfo": "Über & Unterstützen",
 		"dataSource": "Datenquelle",
 		"dataSourceDescription": "Alle Wasserentnahmestellen werden von OpenStreetMap Mitwirkenden bereitgestellt.",
+		"dataAsOf": "Datenstand: {date}",
 		"version": "Version",
 		"supportOnKofiDescription": "Wenn Sie diese App nützlich finden und ihre Entwicklung unterstützen möchten, können Sie mich auf Ko-fi unterstützen! Ihre Unterstützung hält das Projekt am Leben und ermöglicht neue Funktionen.",
 		"addHydrantsTitle": "Wie man Hydranten zu OpenStreetMap hinzufügt",
@@ -301,8 +302,8 @@
 			"description": "Lade einen Bereich herunter, damit die Wasserentnahmestellen auch ohne Verbindung verfügbar bleiben."
 		},
 		"status": {
-			"loadingSources": "Wasserentnahmestellen werden geladen … ({done}/{total})",
-			"refreshingSources": "Wasserentnahmestellen werden aktualisiert … ({done}/{total})",
+			"loadingSources": "Wasserentnahmestellen werden geladen …",
+			"refreshingSources": "Wasserentnahmestellen werden aktualisiert …",
 			"loadingTiles": "Kartenkacheln werden geladen … {percent} %",
 			"refreshingTiles": "Kartenkacheln werden geprüft … {percent} %",
 			"error": "Download unvollständig",
@@ -347,7 +348,7 @@
 			"includeTerrainHint": "Für die Pumpenberechnung offline erforderlich — Geländekacheln liefern die Höhendaten.",
 			"autoRefresh": "Automatisch über WLAN aktualisieren",
 			"autoRefreshHint": "Automatisch über WLAN aktualisieren, wenn älter als 30 Tage.",
-			"estimate": "Etwa {width} × {height} km · {chunks} Datenblöcke",
+			"estimate": "Etwa {width} × {height} km",
 			"sizeEstimate": "Geschätzter Download: {low}–{high} MB",
 			"tooLarge": "Dieser Bereich ist zu groß. Zoome hinein, um einen kleineren Bereich zu wählen.",
 			"download": "Herunterladen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -128,6 +128,7 @@
 		"openInfo": "About & Support",
 		"dataSource": "Data Source",
 		"dataSourceDescription": "All water source data is provided by OpenStreetMap contributors.",
+		"dataAsOf": "Data as of {date}",
 		"version": "Version",
 		"supportOnKofiDescription": "If you find this app useful and want to support its development, consider supporting me on Ko-fi! Your support helps keep the project alive and enables new features.",
 		"addHydrantsTitle": "How to add hydrants to OpenStreetMap",
@@ -301,8 +302,8 @@
 			"description": "Download a district so its water sources stay available without a connection."
 		},
 		"status": {
-			"loadingSources": "Loading water sources… ({done}/{total})",
-			"refreshingSources": "Refreshing water sources… ({done}/{total})",
+			"loadingSources": "Loading water sources…",
+			"refreshingSources": "Refreshing water sources…",
 			"loadingTiles": "Downloading map tiles… {percent}%",
 			"refreshingTiles": "Checking map tiles… {percent}%",
 			"error": "Download incomplete",
@@ -347,7 +348,7 @@
 			"includeTerrainHint": "Needed for the offline pump calculation — terrain tiles provide the elevation data.",
 			"autoRefresh": "Auto-refresh on Wi-Fi",
 			"autoRefreshHint": "Refresh automatically over Wi-Fi when older than 30 days.",
-			"estimate": "About {width} × {height} km · {chunks} data chunks",
+			"estimate": "About {width} × {height} km",
 			"sizeEstimate": "Estimated download: {low}–{high} MB",
 			"tooLarge": "This area is too large. Zoom in to select a smaller region.",
 			"download": "Download",

--- a/src/mapHandler/databaseHandler.ts
+++ b/src/mapHandler/databaseHandler.ts
@@ -1,16 +1,23 @@
 import { openDB } from 'idb';
 import { OverPassElement } from '@/mapHandler/overPassApi';
 import { GeoPoint, GeoBounds, distanceTo, boundsContains } from '@/types/geo';
+import { OsmRef, toRef } from '@/helper/osmRef';
 
-const markerStoreName = 'fireMarker';
+const markerStoreName = 'fireMarkerRefs';
 
 /**
  * A node as it lives in the IndexedDB cache: the raw Overpass element plus
  * cache-only bookkeeping (`__deleted` soft-delete flag and the `fetchedAt`
- * timestamp added in DB v2). The optional fields let it be used anywhere an
- * {@link OverPassElement} is expected while still exposing `fetchedAt`.
+ * timestamp added in DB v2), plus the namespaced {@link OsmRef} that has been
+ * the store's keyPath since DB v4 (§4.5). The optional fields let it be used
+ * anywhere an {@link OverPassElement} is expected while still exposing
+ * `fetchedAt`.
  */
-export type CachedMapNode = OverPassElement & { __deleted?: boolean; fetchedAt?: number };
+export type CachedMapNode = OverPassElement & {
+	ref: OsmRef;
+	__deleted?: boolean;
+	fetchedAt?: number;
+};
 
 const offlineAreasStoreName = 'offlineAreas';
 const pendingEditsStoreName = 'pendingEdits';
@@ -71,11 +78,14 @@ function isDeleted(node: unknown): boolean {
 	return Boolean((node as CachedMapNode | null | undefined)?.__deleted);
 }
 
-const dbPromise = openDB('FireMarker', 3, {
+/** Store name used before the DB v4 namespaced-key migration (§4.5). */
+const legacyMarkerStoreName = 'fireMarker';
+
+const dbPromise = openDB('FireMarker', 4, {
 	async upgrade(db, oldVersion, _newVersion, tx) {
 		if (oldVersion < 1) {
 			// Fresh install: create the store keyed by the node `id`.
-			const store = db.createObjectStore(markerStoreName, {
+			const store = db.createObjectStore(legacyMarkerStoreName, {
 				keyPath: 'id',
 				autoIncrement: true
 			});
@@ -83,7 +93,7 @@ const dbPromise = openDB('FireMarker', 3, {
 		}
 
 		if (oldVersion < 2) {
-			const store = tx.objectStore(markerStoreName);
+			const store = tx.objectStore(legacyMarkerStoreName);
 
 			// The `id` index is redundant — `id` is already the keyPath.
 			if (store.indexNames.contains('id')) {
@@ -119,6 +129,42 @@ const dbPromise = openDB('FireMarker', 3, {
 			});
 			edits.createIndex('status', 'status');
 		}
+
+		if (oldVersion < 4) {
+			// Namespaced marker keys (§4.5): `node/123` and `way/123` are distinct
+			// OSM objects that would overwrite each other under the old bare-`id`
+			// keyPath. IndexedDB cannot change a store's keyPath in place, so we
+			// create a new store keyed by `ref` (`n123` / `w456`), copy every row
+			// across, and drop the old store.
+			//
+			// This MUST be a copy, never a wipe. The old `fireMarker` store also
+			// holds the water-source data for downloaded offline areas while
+			// `offlineAreas` still reports `status: 'ready'` — wiping it here would
+			// leave those areas claiming "ready" with no data behind them, a state
+			// the user only discovers once they are offline and it actually matters.
+			const newStore = db.createObjectStore(markerStoreName, { keyPath: 'ref' });
+			newStore.createIndex('lat, lon', ['lat', 'lon']);
+			newStore.createIndex('fetchedAt', 'fetchedAt');
+
+			// Defensive existence check: the `< 1` block above always creates
+			// `fireMarker` first (even for a brand-new install starting at
+			// `oldVersion === 0`, since every block up to v4 runs in this same
+			// upgrade transaction), so this is always true in practice.
+			if (tx.objectStoreNames.contains(legacyMarkerStoreName)) {
+				const oldStore = tx.objectStore(legacyMarkerStoreName);
+				let cursor = await oldStore.openCursor();
+				while (cursor) {
+					const row = cursor.value as CachedMapNode;
+					// Preserve `__deleted` tombstones and `fetchedAt` (the freshness
+					// index and the startup prune both depend on it), and keep `id`
+					// and `type` on the record — they are the OSM wire identity that
+					// `osm-api` and `fetchNodeById` still need.
+					await newStore.put({ ...row, ref: toRef(row.type ?? 'node', row.id) });
+					cursor = await cursor.continue();
+				}
+				db.deleteObjectStore(legacyMarkerStoreName);
+			}
+		}
 	}
 });
 
@@ -144,11 +190,13 @@ export async function storeMapNodes(nodes: OverPassElement[]) {
 					return;
 				}
 
-				const existing = (await tx.store.get(node.id)) as CachedMapNode | undefined;
+				const ref = toRef(node.type ?? 'node', node.id);
+				const existing = (await tx.store.get(ref)) as CachedMapNode | undefined;
 				const deletedFlag = existing?.__deleted ?? (node as CachedMapNode).__deleted ?? false;
 
 				const toStore: CachedMapNode = {
 					...(node as CachedMapNode),
+					ref,
 					__deleted: deletedFlag,
 					fetchedAt,
 					lat: point.lat,
@@ -243,11 +291,11 @@ export async function getNearbyMapNodes(location: GeoPoint, radius: number) {
 	}
 }
 
-export async function getMapNodeById(id: number) {
+export async function getMapNodeById(ref: OsmRef) {
 	try {
 		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
 		const store = transaction.objectStore(markerStoreName);
-		const result = (await store.get(id)) as CachedMapNode | undefined;
+		const result = (await store.get(ref)) as CachedMapNode | undefined;
 		if (!result || isDeleted(result)) return null;
 		return result;
 	} catch (e) {
@@ -256,7 +304,7 @@ export async function getMapNodeById(id: number) {
 	}
 }
 
-export async function getMapNodeIdsForBounds(mapBounds: GeoBounds): Promise<number[]> {
+export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<OsmRef[]> {
 	try {
 		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
 		const markerStore = transaction.objectStore(markerStoreName);
@@ -267,7 +315,7 @@ export async function getMapNodeIdsForBounds(mapBounds: GeoBounds): Promise<numb
 			[mapBounds.north, mapBounds.east]
 		);
 
-		const ids: number[] = [];
+		const refs: OsmRef[] = [];
 		let cursor = await index.openCursor(range);
 
 		while (cursor) {
@@ -275,24 +323,24 @@ export async function getMapNodeIdsForBounds(mapBounds: GeoBounds): Promise<numb
 			const markerPoint = getNodePoint(mapMarker);
 
 			if (markerPoint && boundsContains(mapBounds, markerPoint)) {
-				ids.push(mapMarker.id);
+				refs.push(mapMarker.ref);
 			}
 
 			cursor = await cursor.continue();
 		}
 
-		return ids;
+		return refs;
 	} catch (e) {
-		console.error('Error getting map node IDs for bounds:', e);
+		console.error('Error getting map node refs for bounds:', e);
 		return [];
 	}
 }
 
-export async function hardDeleteMapNodes(ids: number[]) {
-	if (!ids.length) return;
+export async function hardDeleteMapNodes(refs: OsmRef[]) {
+	if (!refs.length) return;
 	try {
 		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
-		await Promise.all([...ids.map((id) => tx.store.delete(id)), tx.done]);
+		await Promise.all([...refs.map((ref) => tx.store.delete(ref)), tx.done]);
 	} catch (e) {
 		console.error('Error hard-deleting map nodes:', e);
 	}
@@ -336,12 +384,12 @@ export async function pruneStaleMapNodes(maxAgeMs: number) {
 	}
 }
 
-export async function deleteMapNode(id: number) {
+export async function deleteMapNode(ref: OsmRef) {
 	try {
 		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
 
 		// Soft-delete: keep the record in the cache, but mark it as deleted.
-		const existing = (await tx.store.get(id)) as CachedMapNode | undefined;
+		const existing = (await tx.store.get(ref)) as CachedMapNode | undefined;
 
 		if (existing) {
 			await tx.store.put({ ...existing, __deleted: true });

--- a/src/mapHandler/databaseHandler.ts
+++ b/src/mapHandler/databaseHandler.ts
@@ -43,7 +43,14 @@ export interface OfflineArea {
 	sizeBytes: number;
 	status: 'downloading' | 'ready' | 'error' | 'refreshing';
 	progress: { done: number; total: number };
-	/** Resume info: index of the last successfully completed data chunk (−1 = none). */
+	/**
+	 * Data-phase resume state. Originally the index of the last successfully
+	 * completed Overpass chunk (−1 = none); since §4.6 the data phase is a single
+	 * FlatGeobuf read, so the field is repurposed as a tri-state flag — see
+	 * {@link DATA_PHASE_DONE} / {@link DATA_PHASE_PENDING}. The field type is
+	 * unchanged, so records written by older versions still load; any non-negative
+	 * value in one is a legacy chunk index and is treated as "not done".
+	 */
 	lastCompletedChunk: number;
 	/**
 	 * Tile-phase resume cursor: per-source count of tiles already processed
@@ -52,6 +59,34 @@ export interface OfflineArea {
 	 * optional field it needs no IndexedDB migration.
 	 */
 	tileResume?: Record<string, number>;
+}
+
+/**
+ * `lastCompletedChunk` value meaning "the data phase finished for this area".
+ *
+ * Deliberately **not** `0`: before §4.6 the field held a chunk index, where `0`
+ * meant "chunk 0 of N done" — i.e. a *partial* download. Reusing `0` as the done
+ * flag would make every legacy record that got at least one chunk in look fully
+ * downloaded, so a resumed download would skip the data read and leave the area
+ * with a fraction of its water sources. `-2` is outside the legacy value range
+ * (`-1` or a chunk index `>= 0`), so it can only ever have been written by a
+ * version that means it.
+ */
+export const DATA_PHASE_DONE = -2;
+
+/** `lastCompletedChunk` value meaning "the data phase still has to run". */
+export const DATA_PHASE_PENDING = -1;
+
+/**
+ * True when the area's data phase is known to have completed. Legacy chunk
+ * indices (`>= 0`) are *not* accepted: they came from a chunked download whose
+ * completion cannot be reconstructed, so they fall back to "run the data read
+ * again" — a single bbox read that upserts, hence safe to repeat. The record is
+ * normalized to {@link DATA_PHASE_DONE}/{@link DATA_PHASE_PENDING} as soon as
+ * that run persists its progress.
+ */
+export function isDataPhaseDone(area: Pick<OfflineArea, 'lastCompletedChunk'>): boolean {
+	return area.lastCompletedChunk === DATA_PHASE_DONE;
 }
 
 /**

--- a/src/mapHandler/databaseHandler.ts
+++ b/src/mapHandler/databaseHandler.ts
@@ -304,7 +304,17 @@ export async function getMapNodeById(ref: OsmRef) {
 	}
 }
 
-export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<OsmRef[]> {
+/**
+ * A cached node's key plus when we last learned about it. `fetchedAt` lets
+ * deletion reconciliation tell "the source says this is gone" apart from "the
+ * source is simply older than what we know" — see `reconcileDeletedNodes`.
+ */
+export interface CachedNodeRef {
+	ref: OsmRef;
+	fetchedAt: number;
+}
+
+export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<CachedNodeRef[]> {
 	try {
 		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
 		const markerStore = transaction.objectStore(markerStoreName);
@@ -315,7 +325,7 @@ export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<Osm
 			[mapBounds.north, mapBounds.east]
 		);
 
-		const refs: OsmRef[] = [];
+		const refs: CachedNodeRef[] = [];
 		let cursor = await index.openCursor(range);
 
 		while (cursor) {
@@ -323,7 +333,7 @@ export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<Osm
 			const markerPoint = getNodePoint(mapMarker);
 
 			if (markerPoint && boundsContains(mapBounds, markerPoint)) {
-				refs.push(mapMarker.ref);
+				refs.push({ ref: mapMarker.ref, fetchedAt: mapMarker.fetchedAt ?? 0 });
 			}
 
 			cursor = await cursor.continue();

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -9,12 +9,8 @@ import iconWall from '../assets/markers/wall.png';
 import iconWater from '../assets/markers/water.png';
 import iconWaterTank from '../assets/markers/watertank.png';
 
-import {
-	clampBounds,
-	fetchMarkerData,
-	OverPassElement,
-	wasLastAreaQueryFailure
-} from './overPassApi';
+import { clampBounds, OverPassElement } from './overPassApi';
+import { fetchWaterSources, getExtractTimestampMs } from '@/mapHandler/staticDataApi';
 import {
 	getMapNodesForView,
 	getNearbyMapNodes,
@@ -40,29 +36,31 @@ export const markerIconUrls: Record<string, string> = {
 	firestation: iconFirestation
 };
 
+// §4.4 item 3 / plan bug fix: icon and category are decided from tags ONLY,
+// never from `element.type`. Overpass used to query ponds/tanks as
+// `node[…]` exclusively, so branching on `type === 'way'` for "everything
+// else is a fire station" was safe. The FlatGeobuf extract delivers
+// way- and relation-typed hydrants, ponds and tanks too, which would
+// otherwise all render (and filter) as fire stations.
 function getIconKeyForNode(element: OverPassElement): string {
-	if (element.type === 'node') {
-		const emergency = element.tags?.emergency;
-		const type = element.tags?.['fire_hydrant:type'];
-		switch (emergency) {
-			case 'fire_hydrant':
-				return (
-					(
-						{ pillar: 'hydrant', underground: 'underground', wall: 'wall' } as Record<
-							string,
-							string
-						>
-					)[type as string] || 'hydrant'
-				);
-			case 'suction_point':
-				return 'pump';
-			case 'fire_water_pond':
-				return 'water';
-			case 'water_tank':
-				return 'watertank';
+	const emergency = element.tags?.emergency;
+	switch (emergency) {
+		case 'fire_hydrant': {
+			const type = element.tags?.['fire_hydrant:type'];
+			return (
+				({ pillar: 'hydrant', underground: 'underground', wall: 'wall' } as Record<string, string>)[
+					type as string
+				] || 'hydrant'
+			);
 		}
+		case 'suction_point':
+			return 'pump';
+		case 'fire_water_pond':
+			return 'water';
+		case 'water_tank':
+			return 'watertank';
 	}
-	if (element.type === 'way') {
+	if (element.tags?.amenity === 'fire_station') {
 		return 'firestation';
 	}
 	return 'hydrant';
@@ -72,22 +70,20 @@ export function getIconUrlForNode(element: OverPassElement): string {
 	return markerIconUrls[getIconKeyForNode(element)];
 }
 
-/** Maps an OSM element to its filter category key. */
+/** Maps an OSM element to its filter category key. Tags only — see comment above. */
 function categoryForNode(element: OverPassElement): MarkerFilterKey {
-	if (element.type === 'node') {
-		const emergency = element.tags?.emergency;
-		switch (emergency) {
-			case 'fire_hydrant':
-				return 'fireHydrant';
-			case 'suction_point':
-				return 'suctionPoint';
-			case 'water_tank':
-				return 'waterTank';
-			case 'fire_water_pond':
-				return 'fireWaterPond';
-		}
+	const emergency = element.tags?.emergency;
+	switch (emergency) {
+		case 'fire_hydrant':
+			return 'fireHydrant';
+		case 'suction_point':
+			return 'suctionPoint';
+		case 'water_tank':
+			return 'waterTank';
+		case 'fire_water_pond':
+			return 'fireWaterPond';
 	}
-	if (element.type === 'way') return 'fireStation';
+	if (element.tags?.amenity === 'fire_station') return 'fireStation';
 	return 'fireHydrant';
 }
 
@@ -155,16 +151,40 @@ function markTilesFresh(keys: string[]): void {
  * Callers must only invoke this when the fresh result is **not** truncated by
  * the Overpass 2000-element limit, otherwise cut-off nodes would be wrongly
  * deleted. Exported for reuse by the offline area refresh (§1.2).
+ *
+ * `sourceTimestampMs` is the instant the data source is authoritative as of.
+ * Pass it whenever the source can be **older than the cache** — i.e. for the
+ * static extract, which is rebuilt only every couple of days. A cached node the
+ * extract doesn't mention is then deleted only if we learned about it *before*
+ * the extract was cut; anything newer is kept, because the extract cannot know
+ * about it yet. Without this, a marker the user just added through the app
+ * (present in the cache, absent from a days-old extract) would be silently
+ * hard-deleted on the next pan. Omit it for a live source like Overpass, where
+ * absence really does mean deletion.
  */
 export async function reconcileDeletedNodes(
 	mapBounds: GeoBounds,
-	freshElements: OverPassElement[]
+	freshElements: OverPassElement[],
+	sourceTimestampMs?: number
 ) {
 	const freshRefs = new Set<OsmRef>(freshElements.map((e) => toRef(e.type, e.id)));
 	const cachedRefs = await getMapNodeRefsForBounds(mapBounds);
-	const staleRefs = cachedRefs.filter((ref) => !freshRefs.has(ref));
+	const staleRefs = cachedRefs
+		.filter((cached) => !freshRefs.has(cached.ref))
+		.filter((cached) => sourceTimestampMs === undefined || cached.fetchedAt < sourceTimestampMs)
+		.map((cached) => cached.ref);
 	await hardDeleteMapNodes(staleRefs);
 }
+
+/**
+ * `true` when the most recent {@link updateNodeCache} call genuinely failed
+ * (the FGB fetch threw) rather than succeeding with data. Unlike Overpass's
+ * `fetchMarkerData`, `fetchWaterSources` never returns `null` for "aborted or
+ * superseded" — a range read has no such concept — so this is a plain
+ * success/failure flag, not a three-way distinguisher. Mirrors the role
+ * `wasLastAreaQueryFailure()` played for the Overpass path.
+ */
+let lastStaticQueryFailed = false;
 
 async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]> {
 	// Pad the query bbox so small subsequent pans stay inside the fetched area,
@@ -175,17 +195,20 @@ async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]>
 	const queryBounds = clampBounds(padBounds(mapBounds, BBOX_PADDING_RATIO));
 
 	activeAreaFetches.value++;
-	let mapElements: OverPassElement[] | null;
+	let mapElements: OverPassElement[];
 	try {
-		mapElements = await fetchMarkerData(queryBounds);
+		mapElements = await fetchWaterSources(queryBounds);
+		lastStaticQueryFailed = false;
+	} catch (e) {
+		// Unlike fetchMarkerData, fetchWaterSources throws rather than returning
+		// null on failure. Leave the cache untouched — no fresh-tile stamping, no
+		// reconciliation — so a transient outage never looks like "everything in
+		// this area was deleted".
+		console.error('Static water-source fetch failed:', e);
+		lastStaticQueryFailed = true;
+		return [];
 	} finally {
 		activeAreaFetches.value--;
-	}
-
-	// null means the request was aborted or failed — skip cache operations
-	// to avoid falsely deleting cached markers.
-	if (mapElements === null) {
-		return [];
 	}
 
 	// Mark the covering tiles fresh so a following pan within this area can
@@ -193,10 +216,20 @@ async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]>
 	markTilesFresh(coveringTileKeys(queryBounds));
 
 	await storeMapNodes(mapElements);
-	// Only reconcile when the result is not truncated by the 2000-element limit,
-	// otherwise we'd falsely hard-delete nodes that were just cut off.
-	if (mapElements.length < 2000) {
-		await reconcileDeletedNodes(queryBounds, mapElements);
+	// An FGB range read is never truncated the way Overpass's 2000-element
+	// response could be, so — unlike the old Overpass path — reconciliation
+	// always sees the complete set of features the extract holds for
+	// `queryBounds`, and needs no element-count guard.
+	//
+	// It does need a staleness guard instead: the extract is rebuilt only every
+	// couple of days, so it cannot know about anything mapped since it was cut.
+	// Reconciling against its planet timestamp keeps those newer nodes — most
+	// importantly the user's own just-added markers. If the timestamp can't be
+	// determined (metadata unreachable) we skip reconciliation entirely rather
+	// than risk deleting live data; stale nodes are handled by the TTL prune.
+	const extractTimestampMs = await getExtractTimestampMs();
+	if (extractTimestampMs !== null) {
+		await reconcileDeletedNodes(queryBounds, mapElements, extractTimestampMs);
 	}
 
 	// Signal that the cache changed so the map re-renders with the freshly
@@ -245,19 +278,29 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 	const features: GeoJSON.Feature[] = [];
 	try {
 		let mapElements: OverPassElement[] = await getMapNodesForView(mapBounds);
-		// if nothing is in the cache wait for the api call
+
+		// Freshness of the area a fetch would actually cover (padded then clamped,
+		// matching updateNodeCache). Computed for BOTH the empty- and populated-
+		// cache paths: an area that genuinely contains no water sources caches as
+		// "nothing", so a `!mapElements.length` check alone can never become
+		// satisfied and every map move would re-fetch that area forever. The
+		// freshness stamp is the only record that we already asked and the answer
+		// was "none here".
+		const tileKeys = coveringTileKeys(clampBounds(padBounds(mapBounds, BBOX_PADDING_RATIO)));
+		const tilesFresh = areTilesFresh(tileKeys);
+
 		if (!mapElements.length) {
-			mapElements = await updateNodeCache(mapBounds);
-			// updateNodeCache returns [] on both abort and genuine failure.
-			// wasLastAreaQueryFailure() distinguishes them.
-			markerFetchFailed.value = wasLastAreaQueryFailure();
+			// Nothing cached for this view. Fetch only if we haven't already
+			// covered this area within the freshness TTL.
+			if (!tilesFresh) {
+				mapElements = await updateNodeCache(mapBounds);
+				markerFetchFailed.value = lastStaticQueryFailed;
+			}
 		} else {
-			// Cache hit. Skip the background refresh entirely when the area a
-			// fetch would actually cover (padded then clamped, matching
-			// updateNodeCache) was already fetched within the freshness TTL —
-			// avoids redundant Overpass load and rate-limiting on small pans.
-			const tileKeys = coveringTileKeys(clampBounds(padBounds(mapBounds, BBOX_PADDING_RATIO)));
-			if (!areTilesFresh(tileKeys) && !backgroundRefreshInFlight) {
+			// Cache hit. Skip the background refresh entirely when the area was
+			// already fetched within the freshness TTL — avoids redundant load on
+			// small pans.
+			if (!tilesFresh && !backgroundRefreshInFlight) {
 				// Fire-and-forget background cache refresh — silently ignore
 				// abort errors (superseded by a newer request) and network failures.
 				// Background failures while cached data is already on screen are

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -381,7 +381,14 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 				markerFetchFailed.value = lastStaticQueryFailed;
 			}
 		} else {
-			// Cache hit. Skip the background refresh entirely when the area was
+			// Cache hit: this view renders real data, so a failure recorded for a
+			// *different* area no longer describes what the user is looking at.
+			// Without this the flag would stay stuck `true` after one failed
+			// uncached load — the only other writer is the branch above, which
+			// never runs once an area has cached markers.
+			markerFetchFailed.value = false;
+
+			// Skip the background refresh entirely when the area was
 			// already fetched within the freshness TTL — avoids redundant load on
 			// small pans.
 			if (!tilesFresh && !backgroundRefreshInFlight) {

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -9,8 +9,9 @@ import iconWall from '../assets/markers/wall.png';
 import iconWater from '../assets/markers/water.png';
 import iconWaterTank from '../assets/markers/watertank.png';
 
-import { clampBounds, OverPassElement } from './overPassApi';
+import { clampBounds, fetchMarkerData, OverPassElement } from './overPassApi';
 import { fetchWaterSources, getExtractTimestampMs } from '@/mapHandler/staticDataApi';
+import { useNetworkStatus } from '@/composable/networkStatus';
 import {
 	getMapNodesForView,
 	getNearbyMapNodes,
@@ -186,6 +187,89 @@ export async function reconcileDeletedNodes(
  */
 let lastStaticQueryFailed = false;
 
+// --- Opportunistic live refresh (§4.7) -----------------------------------
+// The static extract is rebuilt every couple of days, so it is always somewhat
+// behind OSM. On top of it we ask Overpass for the same viewport in the
+// background: when it answers, the cache picks up edits newer than the extract;
+// when it is rate-limited or down, nothing happens and the user never finds out.
+// This is strictly additive — it can only ever make the map fresher, never
+// break it, which is why every failure path here is silent.
+
+/**
+ * Separate freshness registry from {@link tileFreshness}. The live layer needs
+ * its own TTL because it answers a different question ("has Overpass been asked
+ * about this area recently?") and must not be satisfied by a static read, or
+ * vice versa.
+ */
+const liveFreshness = new Map<string, number>();
+/** Shorter than the static TTL — live data is the whole point of asking. */
+const LIVE_FRESHNESS_TTL_MS = 5 * 60 * 1000;
+
+let liveRefreshInFlight = false;
+
+/** True when every given tile was asked of Overpass within the live TTL. */
+function areTilesLiveFresh(keys: string[]): boolean {
+	const now = Date.now();
+	return keys.every((key) => {
+		const fetchedAt = liveFreshness.get(key);
+		return fetchedAt !== undefined && now - fetchedAt < LIVE_FRESHNESS_TTL_MS;
+	});
+}
+
+/**
+ * Asks Overpass for `mapBounds` in the background and folds whatever comes back
+ * into the cache. Never throws, never blocks rendering, and never touches
+ * {@link markerFetchFailed} — a failure here is a non-event.
+ *
+ * Deliberately **does not reconcile deletions**. Overpass truncates at 2000
+ * elements and can answer partially, so an object missing from its response is
+ * not evidence of deletion (gaps ≠ deletions). It only ever upserts, which is
+ * also why `storeMapNodes` preserving the `__deleted` tombstone matters: a
+ * marker the user deleted locally must not be resurrected by a live refresh.
+ *
+ * No client-side timeout is imposed, despite the plan's suggestion of ~5 s.
+ * Nothing waits on this, and aborting an Overpass query does not refund its
+ * server-side rate-limit slot — so cutting it off early would throw away a
+ * result we had already paid for. `overPassApi` applies its own per-attempt
+ * timeouts, instance pool and 429 cool-downs.
+ */
+async function refreshFromLiveSource(mapBounds: GeoBounds): Promise<void> {
+	// Pointless while offline, and it would only log failures.
+	const { isOnline } = useNetworkStatus();
+	if (!isOnline.value) return;
+	if (liveRefreshInFlight) return;
+
+	// Same padded+clamped bounds the static path uses, so both layers agree on
+	// what "this area" means and the tile keys line up.
+	const queryBounds = clampBounds(padBounds(mapBounds, BBOX_PADDING_RATIO));
+	const keys = coveringTileKeys(queryBounds);
+	if (areTilesLiveFresh(keys)) return;
+
+	liveRefreshInFlight = true;
+	try {
+		const liveElements = await fetchMarkerData(queryBounds);
+		// null = aborted (superseded by a newer pan) or every instance failed.
+		// Leave the tiles unstamped so the next movement tries again.
+		if (liveElements === null) return;
+
+		// Stamp on any answer, including an empty one: "Overpass says there is
+		// nothing here" is a real answer worth not re-asking for a while.
+		const now = Date.now();
+		for (const key of keys) liveFreshness.set(key, now);
+
+		if (liveElements.length === 0) return;
+
+		// Upsert only. storeMapNodes keys by ref and overwrites, so anything
+		// Overpass knows about more recently than the extract wins.
+		await storeMapNodes(liveElements);
+		markerCacheVersion.value++;
+	} catch {
+		// Silent by design — the static layer already rendered.
+	} finally {
+		liveRefreshInFlight = false;
+	}
+}
+
 async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]> {
 	// Pad the query bbox so small subsequent pans stay inside the fetched area,
 	// then apply the same span clamp as the actual query. Freshness stamps and
@@ -313,6 +397,13 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 					});
 			}
 		}
+
+		// Opportunistic live top-up on top of whichever branch ran above (§4.7).
+		// Fire-and-forget: the static data has already been resolved, so this can
+		// only add edits made since the extract was cut. Self-throttled by its own
+		// TTL and in-flight guard, so calling it on every map movement is safe.
+		void refreshFromLiveSource(mapBounds);
+
 		// Apply category filters — call inside the function so Pinia is active.
 		const { markerFilters } = useSettingsStore();
 		for (const element of mapElements) {

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -19,7 +19,7 @@ import {
 	getMapNodesForView,
 	getNearbyMapNodes,
 	storeMapNodes,
-	getMapNodeIdsForBounds,
+	getMapNodeRefsForBounds,
 	hardDeleteMapNodes
 } from '@/mapHandler/databaseHandler';
 import { useMapMarkerStore } from '@/store/mapMarkerStore';
@@ -27,6 +27,7 @@ import { useSettingsStore, type MarkerFilterKey } from '@/store/settingsStore';
 import { NearbyMarker } from '@/composable/nearbyWaterSource';
 import { computeNearbyDistances, NearbyDistanceResult } from '@/mapHandler/nearbyRouting';
 import { lngLatToTile, tileKey } from '@/helper/tileMath';
+import { OsmRef, toRef } from '@/helper/osmRef';
 
 // Map icon keys to URLs for use in MapLibre image loading
 export const markerIconUrls: Record<string, string> = {
@@ -159,10 +160,10 @@ export async function reconcileDeletedNodes(
 	mapBounds: GeoBounds,
 	freshElements: OverPassElement[]
 ) {
-	const freshIds = new Set(freshElements.map((e) => e.id));
-	const cachedIds = await getMapNodeIdsForBounds(mapBounds);
-	const staleIds = cachedIds.filter((id) => !freshIds.has(id));
-	await hardDeleteMapNodes(staleIds);
+	const freshRefs = new Set<OsmRef>(freshElements.map((e) => toRef(e.type, e.id)));
+	const cachedRefs = await getMapNodeRefsForBounds(mapBounds);
+	const staleRefs = cachedRefs.filter((ref) => !freshRefs.has(ref));
+	await hardDeleteMapNodes(staleRefs);
 }
 
 async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]> {
@@ -282,7 +283,7 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 					coordinates: [lng, lat]
 				},
 				properties: {
-					id: element.id,
+					ref: toRef(element.type, element.id),
 					icon: getIconKeyForNode(element)
 				}
 			});
@@ -356,7 +357,7 @@ export async function getNearbyMarkers(latLng: GeoPoint, radius = 2000): Promise
 	return sortElementsByDistance(elements, latLng);
 }
 
-export async function getMarkerById(markerId: number) {
+export async function getMarkerById(ref: OsmRef) {
 	const markerStore = useMapMarkerStore();
-	return markerStore.fetchMarkerById(markerId);
+	return markerStore.fetchMarkerById(ref);
 }

--- a/src/mapHandler/markerImageHandler.ts
+++ b/src/mapHandler/markerImageHandler.ts
@@ -1,3 +1,5 @@
+import { OsmRef, parseRef } from '@/helper/osmRef';
+
 // The MediaWiki API structure
 export interface ImageInfo {
 	// Original file details
@@ -35,11 +37,20 @@ interface ApiResponse {
  * Fetches a list of files from MediaWiki Commons matching a specific prefix
  * and retrieves image information, including a thumbnail of the specified width.
  *
+ * The Commons category convention (`Fire-fighting-facility node-<id>`) is
+ * node-only — there is no equivalent for ways — so this skips the request
+ * entirely for a way ref rather than querying a category that cannot exist.
+ *
  * @returns A promise that resolves to an array of file objects.
- * @param markerId
+ * @param ref
  */
-export async function fetchMediaWikiFiles(markerId: number): Promise<WikiPage[]> {
-	const prefix = `Fire-fighting-facility node-${markerId}`;
+export async function fetchMediaWikiFiles(ref: OsmRef): Promise<WikiPage[]> {
+	const parsed = parseRef(ref);
+	if (parsed?.type !== 'node') {
+		return [];
+	}
+
+	const prefix = `Fire-fighting-facility node-${parsed.id}`;
 	const encodedPrefix = encodeURIComponent(prefix);
 	const apiUrl = 'https://commons.wikimedia.org/w/api.php';
 	const thumbnailWidth = 200;

--- a/src/mapHandler/overPassApi.ts
+++ b/src/mapHandler/overPassApi.ts
@@ -1,5 +1,6 @@
 import { GeoBounds } from '@/types/geo';
 import { Capacitor, CapacitorHttp } from '@capacitor/core';
+import type { OsmType } from '@/helper/osmRef';
 
 // ---------------------------------------------------------------------------
 // Overpass API instance pool
@@ -531,15 +532,20 @@ export async function fetchAreaRaw(
 }
 
 /**
- * Fetches a single node or way by its OSM ID.
+ * Runs a single-element Overpass lookup built from `selectors` (an already
+ * escaped `node(1);way(1);`-style fragment) and returns the first element, or
+ * `null` when nothing matched.
  *
  * Runs against the same {@link OVERPASS_INSTANCES} pool (with shared 429
  * cool-downs) as area queries. An overall client-side timeout of
  * {@link NODE_QUERY_TIMEOUT_MS} ms spans all instance attempts; on timeout or
  * total failure it returns `null`.
  */
-export async function fetchNodeById(nodeId: number): Promise<OverPassElement | null> {
-	const query = `[out:json][timeout:${SERVER_TIMEOUT_SECONDS}];(node(${nodeId});way(${nodeId}););out center tags;`;
+async function fetchSingleElement(
+	selectors: string,
+	label: string
+): Promise<OverPassElement | null> {
+	const query = `[out:json][timeout:${SERVER_TIMEOUT_SECONDS}];(${selectors});out center tags;`;
 
 	const outerSignal = AbortSignal.timeout(NODE_QUERY_TIMEOUT_MS);
 
@@ -548,10 +554,44 @@ export async function fetchNodeById(nodeId: number): Promise<OverPassElement | n
 		return elements.length > 0 ? elements[0] : null;
 	} catch (e) {
 		if (outerSignal.aborted) {
-			console.warn('Overpass node query timed out for node:', nodeId);
+			console.warn('Overpass element query timed out for:', label);
 			return null;
 		}
-		console.error('Error fetching node by ID:', e);
+		console.error('Error fetching element by ID:', e);
 		return null;
 	}
+}
+
+/**
+ * Fetches a single node or way by its OSM ID.
+ *
+ * Kept for callers that only have a bare numeric id and no element type (the
+ * offline edit queue, which only ever deals with nodes). Prefer
+ * {@link fetchElementById} when the type is known: this one queries `node(id)`
+ * and `way(id)` together and returns whichever the server listed first, so for
+ * an id that exists as both it can answer with the wrong element — and it never
+ * finds relations at all.
+ */
+export async function fetchNodeById(nodeId: number): Promise<OverPassElement | null> {
+	return fetchSingleElement(`node(${nodeId});way(${nodeId});`, `node ${nodeId}`);
+}
+
+/** Overpass query keyword for each OSM element type. */
+const OVERPASS_KEYWORD: Record<OsmType, string> = {
+	node: 'node',
+	way: 'way',
+	relation: 'relation'
+};
+
+/**
+ * Fetches one OSM element by its type and ID.
+ *
+ * Unlike {@link fetchNodeById} this queries exactly the requested element type,
+ * so relations resolve (the extract publishes relation-typed ponds and tanks,
+ * §4.5) and a node/way id collision can't return the wrong object.
+ */
+export async function fetchElementById(type: OsmType, id: number): Promise<OverPassElement | null> {
+	const keyword = OVERPASS_KEYWORD[type];
+	if (!keyword) return null;
+	return fetchSingleElement(`${keyword}(${id});`, `${type} ${id}`);
 }

--- a/src/mapHandler/staticDataApi.ts
+++ b/src/mapHandler/staticDataApi.ts
@@ -1,0 +1,248 @@
+/**
+ * Static FlatGeobuf read path (§4.3–§4.4 of `plans/selfhost-osm-data.md`).
+ *
+ * Replaces Overpass as the primary source for viewport marker reads: a bbox
+ * range-read against the self-published `water_sources.fgb` extract, served
+ * from Cloudflare R2 with CORS enabled for the app's web and native origins.
+ * Overpass (`overPassApi.ts`) stays in place for single-node reads (§4.7) and
+ * is untouched here.
+ */
+import { deserialize } from 'flatgeobuf/lib/mjs/geojson';
+import { OverPassElement } from '@/mapHandler/overPassApi';
+import { GeoBounds } from '@/types/geo';
+import { OsmType } from '@/helper/osmRef';
+
+const BASE = import.meta.env.VITE_DATA_BASE_URL ?? 'https://data.fireyak.org/fireyak-data';
+export const FGB_URL = `${BASE}/water_sources.fgb`;
+export const META_URL = `${BASE}/metadata.json`;
+
+/** Shape of `metadata.json` as published by the pipeline. */
+export interface DataMetadata {
+	planet_timestamp: string;
+	feature_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// @id → { type, id } — tolerant of both pipeline export formats
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level flag so the "extract lacks type info" warning fires once per
+ * session rather than once per feature — the fallback below can otherwise run
+ * thousands of times for a single bbox read.
+ */
+let warnedMissingTypeInfo = false;
+
+/** Warns once per session that the extract's `@id` carries no element type. */
+function warnMissingTypeInfoOnce(): void {
+	if (warnedMissingTypeInfo) return;
+	warnedMissingTypeInfo = true;
+	console.warn(
+		'[staticDataApi] water_sources.fgb "@id" is a bare number with no OSM element ' +
+			'type (node/way/relation) — falling back to inferring the type from geometry ' +
+			'(Point → node, else → way). This is transitional: re-run the data pipeline ' +
+			'with --add-unique-id=type_id so "@id" carries the type prefix, then this ' +
+			'fallback stops triggering.'
+	);
+}
+
+/**
+ * Resolves a feature's numeric id and OSM element type from its `@id`
+ * property, tolerant of both export formats the pipeline can currently
+ * produce:
+ *
+ * - **Fixed pipeline** (`--add-unique-id=type_id`): `@id` is a string like
+ *   `"n123"` / `"w456"` / `"r789"` — the prefix gives the type directly.
+ * - **Current, not-yet-fixed pipeline**: `@id` is a bare number with no type
+ *   info. Falls back to inferring the type from the geometry (`Point` → node,
+ *   anything else → way) and warns once per session. Transitional — remove
+ *   once the uploaded extract always carries the typed `@id`.
+ *
+ * Returns `null` if `@id` is missing or unusable.
+ */
+function resolveIdAndType(
+	rawId: unknown,
+	geometry: GeoJSON.Geometry | null
+): { id: number; type: OsmType } | null {
+	if (typeof rawId === 'string') {
+		const match = /^([nwr])(\d+)$/.exec(rawId);
+		if (match) {
+			const type: OsmType = match[1] === 'n' ? 'node' : match[1] === 'w' ? 'way' : 'relation';
+			return { id: Number(match[2]), type };
+		}
+		// Not the typed format — try treating it as a stringified bare number.
+		const numeric = Number(rawId);
+		if (!Number.isFinite(numeric)) return null;
+		warnMissingTypeInfoOnce();
+		return { id: numeric, type: geometry?.type === 'Point' ? 'node' : 'way' };
+	}
+
+	if (typeof rawId === 'number' && Number.isFinite(rawId)) {
+		// Transitional fallback for the currently-uploaded extract — see the
+		// doc comment above.
+		warnMissingTypeInfoOnce();
+		return { id: rawId, type: geometry?.type === 'Point' ? 'node' : 'way' };
+	}
+
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Geometry → coordinates
+// ---------------------------------------------------------------------------
+
+/** Averages the vertices of a single ring/line into one representative point. */
+function averagePosition(
+	positions: GeoJSON.Position[] | undefined
+): { lat: number; lon: number } | null {
+	if (!positions || positions.length === 0) return null;
+	let sumLat = 0;
+	let sumLon = 0;
+	for (const position of positions) {
+		sumLon += position[0];
+		sumLat += position[1];
+	}
+	return { lat: sumLat / positions.length, lon: sumLon / positions.length };
+}
+
+/**
+ * Reduces any GeoJSON geometry to a single representative `{ lat, lon }`.
+ * `Point` returns its own coordinate; polygons/lines average their outer-ring
+ * (or the whole line's) vertices; Multi* geometries use their first member.
+ * Returns `null` when the geometry carries no usable coordinate.
+ */
+function representativePoint(geometry: GeoJSON.Geometry): { lat: number; lon: number } | null {
+	switch (geometry.type) {
+		case 'Point':
+			return { lat: geometry.coordinates[1], lon: geometry.coordinates[0] };
+		case 'Polygon':
+			return averagePosition(geometry.coordinates[0]);
+		case 'MultiPolygon':
+			return averagePosition(geometry.coordinates[0]?.[0]);
+		case 'LineString':
+			return averagePosition(geometry.coordinates);
+		case 'MultiLineString':
+			return averagePosition(geometry.coordinates[0]);
+		default:
+			return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Feature → OverPassElement adapter
+// ---------------------------------------------------------------------------
+
+const META_PROPERTY_PREFIX = '@';
+
+/**
+ * Converts a single FlatGeobuf/GeoJSON feature into the app's
+ * {@link OverPassElement} shape so it can flow through the existing
+ * `storeMapNodes` → IndexedDB cache path unchanged. Returns `null` for
+ * features that can't be resolved to a usable id/type or coordinate.
+ *
+ * Exported so the offline-area downloader (a later task) can reuse it.
+ */
+export function toOverPassElement(feature: GeoJSON.Feature): OverPassElement | null {
+	const geometry = feature.geometry ?? null;
+	if (!geometry) return null;
+
+	const properties = (feature.properties ?? {}) as Record<string, unknown>;
+	const resolved = resolveIdAndType(properties['@id'], geometry);
+	if (!resolved) return null;
+
+	const point = representativePoint(geometry);
+	if (!point) return null;
+
+	const tags: Record<string, string> = {};
+	for (const [key, value] of Object.entries(properties)) {
+		if (key.startsWith(META_PROPERTY_PREFIX)) continue;
+		if (value === null || value === undefined) continue;
+		tags[key] = String(value);
+	}
+
+	const element: OverPassElement = {
+		id: resolved.id,
+		type: resolved.type,
+		tags
+	};
+
+	if (geometry.type === 'Point') {
+		element.lat = point.lat;
+		element.lon = point.lon;
+	} else {
+		element.center = point;
+	}
+
+	return element;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches water-source features intersecting `bounds` from the static
+ * FlatGeobuf extract via an HTTP range read, converting each to an
+ * {@link OverPassElement}. Throws on network/parse failure — unlike
+ * `fetchMarkerData`, which returns `null` — so callers must catch explicitly
+ * (see `markerHandler.ts`'s `updateNodeCache`).
+ */
+export async function fetchWaterSources(bounds: GeoBounds): Promise<OverPassElement[]> {
+	const out: OverPassElement[] = [];
+	for await (const feature of deserialize(FGB_URL, {
+		minX: bounds.west,
+		minY: bounds.south,
+		maxX: bounds.east,
+		maxY: bounds.north
+	})) {
+		const element = toOverPassElement(feature as GeoJSON.Feature);
+		if (element) out.push(element);
+	}
+	return out;
+}
+
+/**
+ * Fetches the published `metadata.json` (planet timestamp + feature count).
+ * Returns `null` on any failure — callers should fall back to a cached value
+ * (see §4.9; not wired up in this change).
+ */
+export async function fetchDataMetadata(): Promise<DataMetadata | null> {
+	try {
+		const response = await fetch(META_URL);
+		if (!response.ok) return null;
+		return (await response.json()) as DataMetadata;
+	} catch (e) {
+		console.error('Error fetching data metadata:', e);
+		return null;
+	}
+}
+
+/**
+ * Process-wide memo of {@link fetchDataMetadata}. The extract is rebuilt every
+ * couple of days, so re-fetching it per bbox read would be pure waste. A failed
+ * lookup is not memoized, so a request made while offline can succeed later.
+ */
+let metadataPromise: Promise<DataMetadata | null> | null = null;
+
+export function getDataMetadata(): Promise<DataMetadata | null> {
+	if (!metadataPromise) {
+		metadataPromise = fetchDataMetadata().then((meta) => {
+			if (!meta) metadataPromise = null;
+			return meta;
+		});
+	}
+	return metadataPromise;
+}
+
+/**
+ * The extract's planet timestamp in epoch-ms, or `null` when it can't be
+ * determined. This is the cut-off the extract can legitimately speak about:
+ * it knows nothing about objects created after it was built, so its silence
+ * about them is not evidence of deletion (see `reconcileDeletedNodes`).
+ */
+export async function getExtractTimestampMs(): Promise<number | null> {
+	const meta = await getDataMetadata();
+	if (!meta?.planet_timestamp) return null;
+	const parsed = Date.parse(meta.planet_timestamp);
+	return Number.isNaN(parsed) ? null : parsed;
+}

--- a/src/mapHandler/staticDataApi.ts
+++ b/src/mapHandler/staticDataApi.ts
@@ -33,58 +33,70 @@ export interface DataMetadata {
  */
 let warnedMissingTypeInfo = false;
 
-/** Warns once per session that the extract's `@id` carries no element type. */
+/** Warns once per session that the extract carries no element type. */
 function warnMissingTypeInfoOnce(): void {
 	if (warnedMissingTypeInfo) return;
 	warnedMissingTypeInfo = true;
 	console.warn(
-		'[staticDataApi] water_sources.fgb "@id" is a bare number with no OSM element ' +
-			'type (node/way/relation) — falling back to inferring the type from geometry ' +
-			'(Point → node, else → way). This is transitional: re-run the data pipeline ' +
-			'with --add-unique-id=type_id so "@id" carries the type prefix, then this ' +
-			'fallback stops triggering.'
+		'[staticDataApi] water_sources.fgb carries no OSM element type: no "@type" ' +
+			'property and "@id" is a bare number — falling back to inferring the type ' +
+			'from geometry (Point → node, else → way), which mislabels relations as ways. ' +
+			"The pipeline's export-config.json already sets attributes.type = true, so " +
+			'this means the running image predates that config: rebuild the Docker image ' +
+			'(the config is COPYed to /etc/osmium-export-config.json at build time, not ' +
+			'read at run time) and re-run the pipeline.'
 	);
 }
 
+/** Maps osmium's `@type` attribute value onto an {@link OsmType}. */
+const OSM_TYPE_BY_NAME: Record<string, OsmType> = {
+	node: 'node',
+	way: 'way',
+	relation: 'relation'
+};
+
 /**
- * Resolves a feature's numeric id and OSM element type from its `@id`
- * property, tolerant of both export formats the pipeline can currently
- * produce:
+ * Resolves a feature's numeric id and OSM element type, accepting every shape
+ * the pipeline can produce, most authoritative first:
  *
- * - **Fixed pipeline** (`--add-unique-id=type_id`): `@id` is a string like
- *   `"n123"` / `"w456"` / `"r789"` — the prefix gives the type directly.
- * - **Current, not-yet-fixed pipeline**: `@id` is a bare number with no type
- *   info. Falls back to inferring the type from the geometry (`Point` → node,
- *   anything else → way) and warns once per session. Transitional — remove
- *   once the uploaded extract always carries the typed `@id`.
+ * 1. **`@type` + numeric `@id`** — what `export-config.json`'s
+ *    `attributes.type = true` produces, and the preferred form: the type is
+ *    explicit and `@id` stays a number, so nothing has to be parsed.
+ * 2. **Typed string `@id`** (`"n123"` / `"w456"` / `"r789"`) — what
+ *    `osmium export --add-unique-id=type_id` produces, supported so either
+ *    pipeline configuration works.
+ * 3. **Bare numeric `@id` with no type at all** — infers the type from the
+ *    geometry (`Point` → node, anything else → way) and warns once per session.
+ *    Transitional and lossy: relations are mislabelled as ways. Remove this
+ *    branch once every published extract carries the type.
  *
  * Returns `null` if `@id` is missing or unusable.
  */
 function resolveIdAndType(
 	rawId: unknown,
+	rawType: unknown,
 	geometry: GeoJSON.Geometry | null
 ): { id: number; type: OsmType } | null {
+	// (1) Explicit `@type` alongside the id — preferred.
+	const declaredType = typeof rawType === 'string' ? OSM_TYPE_BY_NAME[rawType] : undefined;
+
+	// (2) Typed string id, e.g. "w456".
 	if (typeof rawId === 'string') {
 		const match = /^([nwr])(\d+)$/.exec(rawId);
 		if (match) {
-			const type: OsmType = match[1] === 'n' ? 'node' : match[1] === 'w' ? 'way' : 'relation';
-			return { id: Number(match[2]), type };
+			const prefixed: OsmType = match[1] === 'n' ? 'node' : match[1] === 'w' ? 'way' : 'relation';
+			return { id: Number(match[2]), type: declaredType ?? prefixed };
 		}
-		// Not the typed format — try treating it as a stringified bare number.
-		const numeric = Number(rawId);
-		if (!Number.isFinite(numeric)) return null;
-		warnMissingTypeInfoOnce();
-		return { id: numeric, type: geometry?.type === 'Point' ? 'node' : 'way' };
 	}
 
-	if (typeof rawId === 'number' && Number.isFinite(rawId)) {
-		// Transitional fallback for the currently-uploaded extract — see the
-		// doc comment above.
-		warnMissingTypeInfoOnce();
-		return { id: rawId, type: geometry?.type === 'Point' ? 'node' : 'way' };
-	}
+	const numericId = typeof rawId === 'number' ? rawId : Number(rawId);
+	if (!Number.isFinite(numericId)) return null;
 
-	return null;
+	if (declaredType) return { id: numericId, type: declaredType };
+
+	// (3) No type information anywhere — infer it, lossily.
+	warnMissingTypeInfoOnce();
+	return { id: numericId, type: geometry?.type === 'Point' ? 'node' : 'way' };
 }
 
 // ---------------------------------------------------------------------------
@@ -147,7 +159,7 @@ export function toOverPassElement(feature: GeoJSON.Feature): OverPassElement | n
 	if (!geometry) return null;
 
 	const properties = (feature.properties ?? {}) as Record<string, unknown>;
-	const resolved = resolveIdAndType(properties['@id'], geometry);
+	const resolved = resolveIdAndType(properties['@id'], properties['@type'], geometry);
 	if (!resolved) return null;
 
 	const point = representativePoint(geometry);

--- a/src/mapHandler/staticDataApi.ts
+++ b/src/mapHandler/staticDataApi.ts
@@ -8,6 +8,7 @@
  * is untouched here.
  */
 import { deserialize } from 'flatgeobuf/lib/mjs/geojson';
+import { HttpRangeClient } from 'flatgeobuf/lib/mjs/http-reader';
 import { OverPassElement } from '@/mapHandler/overPassApi';
 import { GeoBounds } from '@/types/geo';
 import { OsmType } from '@/helper/osmRef';
@@ -193,20 +194,79 @@ export function toOverPassElement(feature: GeoJSON.Feature): OverPassElement | n
 // ---------------------------------------------------------------------------
 
 /**
+ * A `flatgeobuf` range client that threads an {@link AbortSignal} through to the
+ * underlying `fetch`.
+ *
+ * `deserialize()` takes no signal, and a bbox read is not one request but a
+ * chain of them (header, index, then one batch per run of nearby features).
+ * Breaking out of the consuming loop only stops *future* batches; the request
+ * already in flight would keep downloading — on a large offline-area read that
+ * is megabytes still arriving after the user hit Cancel. The library's own
+ * `HttpRangeClient` is the seam: `BufferedHttpRangeClient` accepts either a URL
+ * or a ready-made client instance (see its constructor's
+ * `source: string | HttpRangeClient`), and the reader passes that same instance
+ * on to every feature batch, so overriding `getRange` here makes *all* of the
+ * read's I/O abortable.
+ */
+class AbortableRangeClient extends HttpRangeClient {
+	private readonly signal: AbortSignal;
+
+	constructor(url: string, signal: AbortSignal) {
+		super(url, false);
+		this.signal = signal;
+	}
+
+	override async getRange(begin: number, length: number): Promise<ArrayBuffer> {
+		this.signal.throwIfAborted();
+
+		this.requestsEverMade += 1;
+		this.bytesEverRequested += length;
+
+		const headers = new Headers(this.headers);
+		headers.set('Range', `bytes=${begin}-${begin + length - 1}`);
+
+		const response = await fetch(this.url, { headers, signal: this.signal });
+		// The base client skips this check, which turns an error page into the
+		// confusing "Not a FlatGeobuf file" further up. A range read answers 206.
+		if (!response.ok) {
+			throw new Error(`Range request for ${this.url} failed with HTTP ${response.status}`);
+		}
+		return response.arrayBuffer();
+	}
+}
+
+/**
  * Fetches water-source features intersecting `bounds` from the static
  * FlatGeobuf extract via an HTTP range read, converting each to an
  * {@link OverPassElement}. Throws on network/parse failure — unlike
  * `fetchMarkerData`, which returns `null` — so callers must catch explicitly
  * (see `markerHandler.ts`'s `updateNodeCache`).
+ *
+ * Pass `signal` to make the read cancellable: it aborts the in-flight range
+ * request and throws `AbortError` instead of running to completion. Callers with
+ * nothing to cancel (the map's viewport read) can omit it.
  */
-export async function fetchWaterSources(bounds: GeoBounds): Promise<OverPassElement[]> {
+export async function fetchWaterSources(
+	bounds: GeoBounds,
+	signal?: AbortSignal
+): Promise<OverPassElement[]> {
+	// `deserialize`'s typings only advertise the URL form, but the range client it
+	// builds internally accepts a prepared client just as well — see
+	// AbortableRangeClient.
+	const source = signal
+		? (new AbortableRangeClient(FGB_URL, signal) as unknown as string)
+		: FGB_URL;
+
 	const out: OverPassElement[] = [];
-	for await (const feature of deserialize(FGB_URL, {
+	for await (const feature of deserialize(source, {
 		minX: bounds.west,
 		minY: bounds.south,
 		maxX: bounds.east,
 		maxY: bounds.north
 	})) {
+		// Stops the generator (and with it any further range requests) as soon as
+		// the caller gives up, even mid-batch.
+		signal?.throwIfAborted();
 		const element = toOverPassElement(feature as GeoJSON.Feature);
 		if (element) out.push(element);
 	}

--- a/src/offline/areaDataDownloader.ts
+++ b/src/offline/areaDataDownloader.ts
@@ -1,50 +1,15 @@
 import { GeoBounds } from '@/types/geo';
-import { fetchAreaRaw } from '@/mapHandler/overPassApi';
+import { fetchWaterSources, getExtractTimestampMs } from '@/mapHandler/staticDataApi';
 import { storeMapNodes } from '@/mapHandler/databaseHandler';
 import { reconcileDeletedNodes } from '@/mapHandler/markerHandler';
+import { toRef } from '@/helper/osmRef';
 
 // ---------------------------------------------------------------------------
 // Tuning
 // ---------------------------------------------------------------------------
 
-/**
- * Chunk edge length in degrees. Kept under the 0.5°/axis clamp that
- * `buildAreaQuery` applies, so no chunk is ever silently shrunk, and small
- * enough to stay well inside Overpass' server timeout and 2000-element limit.
- */
-const CHUNK_STEP_DEGREES = 0.25;
-/** Extra attempts per chunk after the first try fails (2 → up to 3 tries). */
-const CHUNK_RETRIES = 2;
-/** Polite pause between chunks so a large district doesn't hammer Overpass. */
-const CHUNK_SLEEP_MS = 1000;
-/** Overpass truncates an area query at this many elements. */
-const OVERPASS_TRUNCATION_LIMIT = 2000;
-
-/**
- * Splits `bounds` into a grid of `step`-degree chunks (last row/column clamped
- * to the outer edge). Non-overlapping, so a node lands in exactly one chunk.
- */
-export function* chunkBounds(bounds: GeoBounds, step = CHUNK_STEP_DEGREES): Generator<GeoBounds> {
-	for (let south = bounds.south; south < bounds.north; south += step) {
-		for (let west = bounds.west; west < bounds.east; west += step) {
-			yield {
-				south,
-				west,
-				north: Math.min(south + step, bounds.north),
-				east: Math.min(west + step, bounds.east)
-			};
-		}
-	}
-}
-
-/** Number of chunks an area's bounds decompose into (for progress totals). */
-export function countChunks(bounds: GeoBounds): number {
-	let count = 0;
-	for (const _ of chunkBounds(bounds)) count++;
-	return count;
-}
-
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+/** Extra attempts after the first try fails (2 → up to 3 tries total). */
+const READ_RETRIES = 2;
 
 /**
  * Runs `fn`, retrying up to `attempts` extra times on failure. Aborts short-
@@ -65,75 +30,71 @@ async function retry<T>(fn: () => Promise<T>, attempts: number, signal: AbortSig
 }
 
 export interface AreaDownloadProgress {
-	/** Index of the chunk just completed (resume point). */
-	lastCompletedChunk: number;
-	/** Chunks finished so far. */
-	done: number;
-	/** Total chunks in the area. */
-	total: number;
-	/** Running count of distinct nodes stored for the area. */
+	/** `true` once the single data read has completed and been stored. */
+	dataDone: boolean;
+	/** Distinct node count stored for the area (only meaningful once `dataDone`). */
 	nodeCount: number;
 }
 
 export interface DownloadAreaOptions {
 	/** Bounds of the area to download. */
 	bounds: GeoBounds;
-	/** Resume point from a previous run (−1 when starting fresh). */
-	lastCompletedChunk: number;
-	/** Node count carried over from a previous partial run (0 on fresh/refresh). */
-	baseNodeCount: number;
 	/**
-	 * Refresh mode: iterate every chunk from the start and reconcile deletions
-	 * per chunk (nodes gone from OSM are removed from the cache).
+	 * `true` when a previous run already completed the data phase for this area
+	 * — skips the read entirely so a resumed download doesn't re-fetch data it
+	 * already has. Ignored when `refresh` is set: a refresh always re-reads, both
+	 * to pick up new data and to reconcile deletions.
+	 */
+	alreadyDownloaded: boolean;
+	/**
+	 * Refresh mode: re-read the whole area even if already downloaded, and
+	 * reconcile deletions against the fresh result (guarded by the extract's
+	 * staleness — see {@link reconcileDeletedNodes}).
 	 */
 	refresh: boolean;
-	/** Persisted after every completed chunk (DB write + reactive update). */
+	/** Called once the data phase finishes (or is skipped as already-done). */
 	onProgress: (progress: AreaDownloadProgress) => void | Promise<void>;
 }
 
 /**
- * Downloads all water-source data for an area, chunk by chunk, resuming at
- * `lastCompletedChunk + 1`. Each chunk is stored immediately so progress is
- * durable if the app is killed mid-download. On `refresh`, deletions are
- * reconciled per chunk (guarded against the truncation limit).
+ * Downloads all water-source data for an area via a single FlatGeobuf bbox
+ * range read (§4.6 of `plans/selfhost-osm-data.md`) — no chunking, no
+ * rate-limit pacing, and no truncation guard, since a range read is never
+ * truncated the way Overpass's 2000-element response could be.
  *
- * Throws `AbortError` when cancelled and re-throws the last chunk error when a
- * chunk fails after all retries — the caller marks the area `error` and can
- * resume later from the persisted `lastCompletedChunk`.
+ * On `refresh`, deletions are reconciled against the extract's planet
+ * timestamp: a cached node absent from the read is hard-deleted only if it was
+ * learned about *before* the extract was cut, so a marker the user just added
+ * through the app (or any other post-cut change) survives. If the timestamp
+ * can't be determined, reconciliation is skipped entirely for this run.
+ *
+ * Throws `AbortError` when cancelled, and re-throws the read's error when it
+ * fails after all retries — the caller marks the area `error` and can resume
+ * later (the persisted "already downloaded" flag makes a resume a no-op for
+ * the data phase if the read had actually succeeded before the failure).
  */
 export async function downloadAreaData(
 	options: DownloadAreaOptions,
 	signal: AbortSignal
 ): Promise<void> {
-	const chunks = [...chunkBounds(options.bounds)];
-	const total = chunks.length;
-	const start = options.refresh ? 0 : options.lastCompletedChunk + 1;
-	const baseNodeCount = options.refresh ? 0 : options.baseNodeCount;
+	if (options.alreadyDownloaded && !options.refresh) return;
 
-	// Distinct node ids seen during this run; chunks don't overlap, so this is an
-	// accurate delta on top of `baseNodeCount`.
-	const seenIds = new Set<number>();
+	if (signal.aborted) throw new DOMException('Download aborted', 'AbortError');
 
-	for (let i = start; i < total; i++) {
-		const elements = await retry(() => fetchAreaRaw(chunks[i], signal), CHUNK_RETRIES, signal);
+	const elements = await retry(() => fetchWaterSources(options.bounds), READ_RETRIES, signal);
 
-		await storeMapNodes(elements);
+	if (signal.aborted) throw new DOMException('Download aborted', 'AbortError');
 
-		// Only reconcile deletions when the chunk was not truncated, otherwise
-		// cut-off nodes would be wrongly hard-deleted.
-		if (options.refresh && elements.length < OVERPASS_TRUNCATION_LIMIT) {
-			await reconcileDeletedNodes(chunks[i], elements);
+	await storeMapNodes(elements);
+
+	if (options.refresh) {
+		const sourceTimestampMs = await getExtractTimestampMs();
+		if (sourceTimestampMs !== null) {
+			await reconcileDeletedNodes(options.bounds, elements, sourceTimestampMs);
 		}
-
-		for (const element of elements) seenIds.add(element.id);
-
-		await options.onProgress({
-			lastCompletedChunk: i,
-			done: i + 1,
-			total,
-			nodeCount: baseNodeCount + seenIds.size
-		});
-
-		if (i < total - 1) await sleep(CHUNK_SLEEP_MS);
 	}
+
+	const distinctRefs = new Set(elements.map((element) => toRef(element.type, element.id)));
+
+	await options.onProgress({ dataDone: true, nodeCount: distinctRefs.size });
 }

--- a/src/offline/areaDataDownloader.ts
+++ b/src/offline/areaDataDownloader.ts
@@ -81,7 +81,13 @@ export async function downloadAreaData(
 
 	if (signal.aborted) throw new DOMException('Download aborted', 'AbortError');
 
-	const elements = await retry(() => fetchWaterSources(options.bounds), READ_RETRIES, signal);
+	// The signal goes into the read itself, not just around it: a cancel has to
+	// abort the range requests in flight, not wait for them to finish.
+	const elements = await retry(
+		() => fetchWaterSources(options.bounds, signal),
+		READ_RETRIES,
+		signal
+	);
 
 	if (signal.aborted) throw new DOMException('Download aborted', 'AbortError');
 

--- a/src/offline/editQueue.ts
+++ b/src/offline/editQueue.ts
@@ -16,6 +16,7 @@ import {
 	hardDeleteMapNodes
 } from '@/mapHandler/databaseHandler';
 import { markerCacheVersion } from '@/mapHandler/markerHandler';
+import { toRef } from '@/helper/osmRef';
 
 // ---------------------------------------------------------------------------
 // Offline edit queue + sync engine (§1.3)
@@ -120,7 +121,7 @@ export async function enqueueEdit(input: EnqueueInput): Promise<void> {
 			// The create never hit OSM: dropping the queue entry and the temp node
 			// makes it as if the marker was never added.
 			if (create?.localId != null) await deletePendingEdit(create.localId);
-			await hardDeleteMapNodes([input.osmId]);
+			await hardDeleteMapNodes([toRef('node', input.osmId)]);
 			markerCacheVersion.value++;
 			return;
 		}
@@ -157,7 +158,7 @@ export async function enqueueEdit(input: EnqueueInput): Promise<void> {
 
 	// Optimistic cache update so the map reflects the edit immediately.
 	if (input.action === 'delete') {
-		await deleteMapNode(osmId);
+		await deleteMapNode(toRef('node', osmId));
 	} else {
 		await storeMapNodes([
 			{ id: osmId, type: 'node', lat: input.lat, lon: input.lon, tags: input.tags }
@@ -217,10 +218,10 @@ async function uploadDelete(edit: PendingEdit): Promise<void> {
  * later queue entries that were enqueued against the temp ID.
  */
 async function remapTempId(tempId: number, newId: number): Promise<void> {
-	const node = await getMapNodeById(tempId);
+	const node = await getMapNodeById(toRef('node', tempId));
 	if (node) {
 		await storeMapNodes([{ ...node, id: newId }]);
-		await hardDeleteMapNodes([tempId]);
+		await hardDeleteMapNodes([toRef('node', tempId)]);
 		markerCacheVersion.value++;
 	}
 
@@ -326,7 +327,7 @@ export async function discardEdit(localId: number): Promise<void> {
 	await deletePendingEdit(localId);
 
 	if (edit.action === 'create') {
-		await hardDeleteMapNodes([edit.osmId]);
+		await hardDeleteMapNodes([toRef(edit.elementType, edit.osmId)]);
 		markerCacheVersion.value++;
 		return;
 	}

--- a/src/store/mapMarkerStore.ts
+++ b/src/store/mapMarkerStore.ts
@@ -2,7 +2,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { OverPassElement } from '@/mapHandler/overPassApi';
-import { fetchNodeById } from '@/mapHandler/overPassApi';
+import { fetchElementById } from '@/mapHandler/overPassApi';
 import { CachedMapNode, getMapNodeById, storeMapNodes } from '@/mapHandler/databaseHandler';
 import { fetchMediaWikiFiles, ImageInfo } from '@/mapHandler/markerImageHandler';
 import { useNetworkStatus } from '@/composable/networkStatus';
@@ -29,19 +29,19 @@ export const useMapMarkerStore = defineStore('marker', () => {
 
 				// If not in database, fetch from API
 				if (!node) {
-					// Overpass keys nodes and ways by numeric id in separate element
-					// types; the ref's numeric id is all `fetchNodeById` needs, it
-					// queries both `node(id)` and `way(id)`.
+					// The ref carries the element type, so ask Overpass for exactly
+					// that type. Relations matter here: the extract publishes
+					// relation-typed ponds and tanks, and a bare `node(id);way(id)`
+					// lookup would never find them — an `r…` marker opened from a
+					// shared link or a cache miss would resolve to nothing.
 					const parsed = parseRef(ref);
-					const fetched = parsed ? await fetchNodeById(parsed.id) : null;
+					const fetched = parsed ? await fetchElementById(parsed.type, parsed.id) : null;
 					if (fetched) {
 						// Store in database for future use — the element is valid data
 						// regardless of whether it is the one that was asked for.
 						await storeMapNodes([fetched]);
-						// `fetchNodeById` queries `node(id)` and `way(id)` together and
-						// returns whichever came back first, so for an id that exists as
-						// both it can answer with the wrong element type. Only adopt it
-						// when it actually matches the requested ref.
+						// Guard against a response that isn't the element we asked for
+						// (a differently-typed element with the same numeric id).
 						const fetchedRef = toRef(fetched.type, fetched.id);
 						node = fetchedRef === ref ? { ...fetched, ref: fetchedRef } : null;
 					}

--- a/src/store/mapMarkerStore.ts
+++ b/src/store/mapMarkerStore.ts
@@ -6,49 +6,61 @@ import { fetchNodeById } from '@/mapHandler/overPassApi';
 import { CachedMapNode, getMapNodeById, storeMapNodes } from '@/mapHandler/databaseHandler';
 import { fetchMediaWikiFiles, ImageInfo } from '@/mapHandler/markerImageHandler';
 import { useNetworkStatus } from '@/composable/networkStatus';
+import { OsmRef, parseRef, toRef } from '@/helper/osmRef';
 
 export const useMapMarkerStore = defineStore('marker', () => {
 	// State
-	const fetchPromises = ref<Map<number, Promise<CachedMapNode | null>>>(new Map());
+	const fetchPromises = ref<Map<OsmRef, Promise<CachedMapNode | null>>>(new Map());
 	const selectedMarker = ref<CachedMapNode | null>(null);
 	const selectedMarkerImages = ref<ImageInfo[]>([]);
 
 	// Actions
-	async function fetchMarkerById(markerId: number): Promise<CachedMapNode | null> {
+	async function fetchMarkerById(ref: OsmRef): Promise<CachedMapNode | null> {
 		// Return in-flight promise if already fetching
-		if (fetchPromises.value.has(markerId)) {
-			return fetchPromises.value.get(markerId) || null;
+		if (fetchPromises.value.has(ref)) {
+			return fetchPromises.value.get(ref) || null;
 		}
 
 		// Create fetch promise
 		const fetchPromise = (async () => {
 			try {
 				// Try database first
-				let node = await getMapNodeById(markerId);
+				let node = await getMapNodeById(ref);
 
 				// If not in database, fetch from API
 				if (!node) {
-					node = await fetchNodeById(markerId);
-					// Store in database for future use
-					if (node) {
-						await storeMapNodes([node]);
+					// Overpass keys nodes and ways by numeric id in separate element
+					// types; the ref's numeric id is all `fetchNodeById` needs, it
+					// queries both `node(id)` and `way(id)`.
+					const parsed = parseRef(ref);
+					const fetched = parsed ? await fetchNodeById(parsed.id) : null;
+					if (fetched) {
+						// Store in database for future use — the element is valid data
+						// regardless of whether it is the one that was asked for.
+						await storeMapNodes([fetched]);
+						// `fetchNodeById` queries `node(id)` and `way(id)` together and
+						// returns whichever came back first, so for an id that exists as
+						// both it can answer with the wrong element type. Only adopt it
+						// when it actually matches the requested ref.
+						const fetchedRef = toRef(fetched.type, fetched.id);
+						node = fetchedRef === ref ? { ...fetched, ref: fetchedRef } : null;
 					}
 				}
 
 				return node;
 			} finally {
 				// Cleanup
-				fetchPromises.value.delete(markerId);
+				fetchPromises.value.delete(ref);
 			}
 		})();
 
 		// Cache the promise
-		fetchPromises.value.set(markerId, fetchPromise);
+		fetchPromises.value.set(ref, fetchPromise);
 
 		return fetchPromise;
 	}
 
-	async function fetchMarkerImageInfoById(markerId: number) {
+	async function fetchMarkerImageInfoById(ref: OsmRef) {
 		// Photo galleries (Wikimedia Commons) need a connection — skip the
 		// request entirely while offline instead of letting it fail.
 		const { isOnline } = useNetworkStatus();
@@ -57,7 +69,7 @@ export const useMapMarkerStore = defineStore('marker', () => {
 			return [];
 		}
 
-		const imageData = await fetchMediaWikiFiles(markerId);
+		const imageData = await fetchMediaWikiFiles(ref);
 		const imageDataList: ImageInfo[] = [];
 		imageData.forEach((image) => {
 			imageDataList.push(...image.imageinfo);
@@ -66,23 +78,24 @@ export const useMapMarkerStore = defineStore('marker', () => {
 		return imageDataList;
 	}
 
-	async function selectMarker(markerId: number | null) {
+	async function selectMarker(ref: OsmRef | null) {
 		selectedMarker.value = null;
 		selectedMarkerImages.value.length = 0;
 
-		if (markerId) {
+		if (ref) {
 			selectedMarkerImages.value.length = 0;
-			const marker = await fetchMarkerById(markerId);
+			const marker = await fetchMarkerById(ref);
 			if (marker) {
 				selectedMarker.value = marker;
-				fetchMarkerImageInfoById(markerId);
+				fetchMarkerImageInfoById(ref);
 			}
 		}
 	}
 
 	function updateSelectedMarker(marker: OverPassElement) {
-		if (selectedMarker.value && selectedMarker.value.id === marker.id) {
-			selectedMarker.value = marker;
+		const ref = toRef(marker.type, marker.id);
+		if (selectedMarker.value && selectedMarker.value.ref === ref) {
+			selectedMarker.value = { ...marker, ref };
 		}
 	}
 

--- a/src/store/markerEditStore.ts
+++ b/src/store/markerEditStore.ts
@@ -14,6 +14,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { version } from '@/../package.json';
 import { useNetworkStatus } from '@/composable/networkStatus';
 import { enqueueEdit, isNetworkError } from '@/offline/editQueue';
+import { toRef } from '@/helper/osmRef';
 
 export const useMarkerEditStore = defineStore('markerEdit', () => {
 	const isEditing = ref(false);
@@ -328,7 +329,7 @@ export const useMarkerEditStore = defineStore('markerEdit', () => {
 				change
 			);
 
-			await deleteMapNode(originalMarker.value.id);
+			await deleteMapNode(toRef('node', originalMarker.value.id));
 			markerCacheVersion.value++;
 			markerStore.selectMarker(null);
 			cancelEdit();

--- a/src/store/offlineAreasStore.ts
+++ b/src/store/offlineAreasStore.ts
@@ -6,7 +6,10 @@ import {
 	getAllOfflineAreas,
 	addOfflineArea,
 	updateOfflineArea,
-	deleteOfflineArea
+	deleteOfflineArea,
+	isDataPhaseDone,
+	DATA_PHASE_DONE,
+	DATA_PHASE_PENDING
 } from '@/mapHandler/databaseHandler';
 import { downloadAreaData } from '@/offline/areaDataDownloader';
 import { downloadTiles, downloadStyleAssets } from '@/offline/tileDownloader';
@@ -178,10 +181,12 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 		// live per-source tallies summed into the persisted `done`.
 		const combinedTotal = combinedTotalFor(area);
 		// `lastCompletedChunk` no longer indexes a chunk (§4.6) — it is repurposed
-		// as a simple "data phase done" flag: `-1` = not yet done, `0` = done. The
-		// DB field is kept as-is (still a `number`) so no migration is needed.
-		const dataPhaseFlag = refresh ? -1 : area.lastCompletedChunk;
-		const dataAlreadyDone = dataPhaseFlag >= 0;
+		// as a "data phase done" flag (see `isDataPhaseDone`). The DB field is kept
+		// as-is (still a `number`) so no schema migration is needed; records left
+		// over from the chunked downloader carry a chunk index, which counts as
+		// "not done" and is normalized by the persist below.
+		const dataAlreadyDone = !refresh && isDataPhaseDone(area);
+		const dataPhaseFlag = dataAlreadyDone ? DATA_PHASE_DONE : DATA_PHASE_PENDING;
 		let dataDone = dataAlreadyDone ? DATA_PHASE_UNITS : 0;
 
 		// Tile-phase resume state. Reset on refresh (re-verify every tile — cheap,
@@ -224,7 +229,7 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 				onProgress: (progress) => {
 					dataDone = progress.dataDone ? DATA_PHASE_UNITS : 0;
 					return persist(id, {
-						lastCompletedChunk: progress.dataDone ? 0 : -1,
+						lastCompletedChunk: progress.dataDone ? DATA_PHASE_DONE : DATA_PHASE_PENDING,
 						progress: { done: dataDone + tilesProcessed, total: combinedTotal },
 						nodeCount: progress.nodeCount
 					});
@@ -314,7 +319,7 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 			// Placeholder — `combinedTotalFor` needs `bounds`/`includeSatellite`/
 			// `includeTerrain`, all already set above.
 			progress: { done: 0, total: 0 },
-			lastCompletedChunk: -1
+			lastCompletedChunk: DATA_PHASE_PENDING
 		};
 		record.progress.total = combinedTotalFor(record);
 
@@ -326,8 +331,8 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 
 	/**
 	 * Resumes a failed/partial download: skips the data phase if it already
-	 * completed (`lastCompletedChunk >= 0`) and the tile phase resumes from its
-	 * own `tileResume` cursor.
+	 * completed (see `isDataPhaseDone`) and the tile phase resumes from its own
+	 * `tileResume` cursor.
 	 */
 	async function retryArea(id: number): Promise<void> {
 		await runDownload(id, false);

--- a/src/store/offlineAreasStore.ts
+++ b/src/store/offlineAreasStore.ts
@@ -8,7 +8,7 @@ import {
 	updateOfflineArea,
 	deleteOfflineArea
 } from '@/mapHandler/databaseHandler';
-import { countChunks, downloadAreaData } from '@/offline/areaDataDownloader';
+import { downloadAreaData } from '@/offline/areaDataDownloader';
 import { downloadTiles, downloadStyleAssets } from '@/offline/tileDownloader';
 import { tileStore } from '@/offline/tileStore';
 import {
@@ -78,6 +78,20 @@ function tileJobsFor(area: OfflineArea): TileJob[] {
 /** Total tiles across all of the area's enabled sources (for the progress total). */
 function totalTilesFor(area: OfflineArea): number {
 	return tileJobsFor(area).reduce((sum, job) => sum + tileCount(area.bounds, 0, job.zMax), 0);
+}
+
+/**
+ * Progress weight of the data phase (§4.6): a single FlatGeobuf bbox read has
+ * no meaningful sub-steps to report, unlike the old per-chunk Overpass loop, so
+ * it collapses to one unit of the combined bar. Tiles remain the overwhelming
+ * bulk of the total, so this keeps the bar smooth and monotonic without making
+ * the data phase invisible.
+ */
+const DATA_PHASE_UNITS = 1;
+
+/** Combined progress total: the one-unit data phase plus every enabled tile source. */
+function combinedTotalFor(area: OfflineArea): number {
+	return DATA_PHASE_UNITS + totalTilesFor(area);
 }
 
 export interface CreateAreaInput {
@@ -159,13 +173,16 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 		controllers.set(id, controller);
 		const signal = controller.signal;
 
-		// Unified progress: Overpass data chunks + tiles run in parallel and both
-		// count toward one bar. `total` covers both; `dataDone`/`tilesProcessed`
-		// are the live per-source tallies summed into the persisted `done`.
-		const dataTotal = countChunks(area.bounds);
-		const combinedTotal = dataTotal + totalTilesFor(area);
-		const startChunk = refresh ? -1 : area.lastCompletedChunk;
-		let dataDone = Math.max(startChunk + 1, 0);
+		// Unified progress: the data read + tiles run in parallel and both count
+		// toward one bar. `total` covers both; `dataDone`/`tilesProcessed` are the
+		// live per-source tallies summed into the persisted `done`.
+		const combinedTotal = combinedTotalFor(area);
+		// `lastCompletedChunk` no longer indexes a chunk (§4.6) — it is repurposed
+		// as a simple "data phase done" flag: `-1` = not yet done, `0` = done. The
+		// DB field is kept as-is (still a `number`) so no migration is needed.
+		const dataPhaseFlag = refresh ? -1 : area.lastCompletedChunk;
+		const dataAlreadyDone = dataPhaseFlag >= 0;
+		let dataDone = dataAlreadyDone ? DATA_PHASE_UNITS : 0;
 
 		// Tile-phase resume state. Reset on refresh (re-verify every tile — cheap,
 		// has() hits skip re-download); carried over on retry.
@@ -193,22 +210,21 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 
 		await persist(id, {
 			status: refresh ? 'refreshing' : 'downloading',
-			lastCompletedChunk: startChunk,
+			lastCompletedChunk: dataPhaseFlag,
 			progress: { done: dataDone + tilesProcessed, total: combinedTotal }
 		});
 
-		// Overpass data and tiles download concurrently: the Overpass timeout/retry
-		// handling overlaps with productive tile downloading instead of blocking it.
+		// The data read and tiles download concurrently: the read's retry handling
+		// overlaps with productive tile downloading instead of blocking it.
 		const dataTask = downloadAreaData(
 			{
 				bounds: area.bounds,
-				lastCompletedChunk: startChunk,
-				baseNodeCount: area.nodeCount,
+				alreadyDownloaded: dataAlreadyDone,
 				refresh,
 				onProgress: (progress) => {
-					dataDone = progress.done;
+					dataDone = progress.dataDone ? DATA_PHASE_UNITS : 0;
 					return persist(id, {
-						lastCompletedChunk: progress.lastCompletedChunk,
+						lastCompletedChunk: progress.dataDone ? 0 : -1,
 						progress: { done: dataDone + tilesProcessed, total: combinedTotal },
 						nodeCount: progress.nodeCount
 					});
@@ -295,9 +311,12 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 			tileCount: 0,
 			sizeBytes: 0,
 			status: 'downloading',
-			progress: { done: 0, total: countChunks(input.bounds) },
+			// Placeholder — `combinedTotalFor` needs `bounds`/`includeSatellite`/
+			// `includeTerrain`, all already set above.
+			progress: { done: 0, total: 0 },
 			lastCompletedChunk: -1
 		};
+		record.progress.total = combinedTotalFor(record);
 
 		const id = await addOfflineArea(record);
 		areas.value.push({ ...record, id });
@@ -305,7 +324,11 @@ export const useOfflineAreasStore = defineStore('offlineAreas', () => {
 		return id;
 	}
 
-	/** Resumes a failed/partial download at the last completed chunk + 1. */
+	/**
+	 * Resumes a failed/partial download: skips the data phase if it already
+	 * completed (`lastCompletedChunk >= 0`) and the tile phase resumes from its
+	 * own `tileResume` cursor.
+	 */
 	async function retryArea(id: number): Promise<void> {
 		await runDownload(id, false);
 	}

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -97,6 +97,9 @@
 					</ion-card-header>
 					<ion-card-content>
 						<p>{{ $t('about.dataSourceDescription') }}</p>
+						<p v-if="dataAsOf" class="data-as-of">
+							{{ $t('about.dataAsOf', { date: dataAsOf }) }}
+						</p>
 						<ion-button
 							expand="block"
 							fill="outline"
@@ -132,16 +135,21 @@ import {
 	IonBackButton
 } from '@ionic/vue';
 import { logoGithub, heart, star, bug, code, documentText, map, sparkles } from 'ionicons/icons';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { App } from '@capacitor/app';
 import { AppInfo } from '@capacitor/app/dist/esm/definitions';
 import { Capacitor } from '@capacitor/core';
 import { version } from '@/../package.json';
 import { useWhatsNew } from '@/composable/whatsNew';
+import { useDataFreshness } from '@/composable/dataFreshness';
 
 const { openHistory } = useWhatsNew();
+const { planetTimestamp, load: loadDataFreshness, formatted } = useDataFreshness();
 
 const appInfo = ref<Partial<AppInfo> | null>(null);
+
+/** Re-evaluates once the timestamp resolves; `null` hides the line entirely. */
+const dataAsOf = computed(() => (planetTimestamp.value ? formatted() : null));
 
 onMounted(async () => {
 	if (Capacitor.isNativePlatform()) {
@@ -149,6 +157,7 @@ onMounted(async () => {
 	} else {
 		appInfo.value = { version: version };
 	}
+	void loadDataFreshness();
 });
 </script>
 
@@ -157,6 +166,11 @@ onMounted(async () => {
 	max-width: 800px;
 	margin: 0 auto;
 	padding: 16px;
+}
+
+.data-as-of {
+	color: var(--ion-color-medium);
+	font-size: 0.875rem;
 }
 
 .logo-section {

--- a/src/views/MarkerImageViewer.vue
+++ b/src/views/MarkerImageViewer.vue
@@ -26,6 +26,7 @@ import PhotoSwipeLightbox from 'photoswipe/lightbox';
 import 'photoswipe/photoswipe.css';
 import { useMapMarkerStore } from '@/store/mapMarkerStore';
 import { useNetworkStatus } from '@/composable/networkStatus';
+import { coerceRef } from '@/helper/osmRef';
 
 const ionRouter = useIonRouter();
 const route = useRoute();
@@ -53,7 +54,10 @@ onMounted(async () => {
 
 	let markerImages = selectedMarkerImages;
 	if (!markerImages.length) {
-		markerImages = await fetchMarkerImageInfoById(parseInt(route.params.relatedId as string));
+		const ref = coerceRef(route.params.relatedId as string);
+		if (ref) {
+			markerImages = await fetchMarkerImageInfoById(ref);
+		}
 	}
 
 	// Map fetched image data to PhotoSwipe item format

--- a/src/views/OfflineAreasView.vue
+++ b/src/views/OfflineAreasView.vue
@@ -45,9 +45,9 @@
 					<ion-label>
 						<h2>{{ area.name }}</h2>
 						<p>{{ statusLine(area) }}</p>
-						<!-- Water-source (Overpass) data and tiles download in parallel and
-						     both count toward one determinate bar; the status line notes
-						     while the water-source fetch is still pending. -->
+						<!-- Water-source data and tiles download in parallel and both count
+						     toward one determinate bar; the status line notes while the
+						     water-source read is still pending. -->
 						<ion-progress-bar
 							v-if="area.status === 'downloading' || area.status === 'refreshing'"
 							type="determinate"
@@ -201,7 +201,6 @@ import { storeToRefs } from 'pinia';
 import { GeoBounds, GeoPoint } from '@/types/geo';
 import { useNetworkStatus } from '@/composable/networkStatus';
 import { useOfflineAreasStore, isAreaTooLarge } from '@/store/offlineAreasStore';
-import { countChunks } from '@/offline/areaDataDownloader';
 import {
 	useOfflineAreaActions,
 	estimateSourceBytes,
@@ -314,8 +313,7 @@ const estimateLine = computed(() => {
 	const heightKm = (b.north - b.south) * 111;
 	return t('offlineAreas.add.estimate', {
 		width: widthKm.toFixed(1),
-		height: heightKm.toFixed(1),
-		chunks: countChunks(b)
+		height: heightKm.toFixed(1)
 	});
 });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,9 @@
 
 interface ImportMetaEnv {
 	readonly VITE_PROTOMAPS_API_KEY: string;
+	/** Overrides the base URL for the static OSM data extract (§4.3). Defaults
+	 * to the production R2 custom domain when unset — see `staticDataApi.ts`. */
+	readonly VITE_DATA_BASE_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Replaces Overpass as the primary source for viewport marker reads with a self-hosted static extract (FlatGeobuf on Cloudflare R2), read via HTTP range requests keyed to the visible bounds. Overpass stays in place for single-node reads and now also does opportunistic background top-ups so the map benefits from live edits without depending on Overpass for the initial load.
- Namespaces cached marker keys by OSM element type (`n123`/`w456`/`r789`) to fix a node/way id collision in the local cache, with an IndexedDB `v3` → `v4` migration that copies existing rows into the new store.
- Reworks the offline-area downloader to use the same static-extract read instead of chunked Overpass queries, and shows a "Data as of …" freshness line on the About page.

See `plans/selfhost-osm-data.md` for the full design, including the reconciliation staleness guard and the live-refresh throttling design.

## Type of change

- [x] ✨ New feature (`feat:`)

## How was it tested?

- Web (`npm run dev` / built bundle) — verified empty-area load (no infinite fetch loop), offline-area download against the static extract, and About page freshness display via headless browser checks.
- [ ] Android (device or emulator)
- [ ] iOS (device or simulator)

Gates run on every change in this branch: `npm run build`, `npx eslint .`, `npx vue-tsc --noEmit` (no new errors beyond the two pre-existing ones).

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run build` and lint pass locally
- [x] New user-facing strings added to both `src/locales/en.json` and `src/locales/de.json`
- [x] What's New entry added to `src/assets/whats-new.json` (en + de)
- [x] No secrets, API keys, or personal data in the diff
- [ ] Screenshots attached for UI changes (About page freshness line is a minor text addition; no screenshot attached)

## Notes for reviewers

- The static extract's R2 upload path currently doesn't match the app's read prefix (pipeline-side `build.sh` change, tracked separately) — the app itself is source-agnostic to that and will pick up fixed data automatically once resolved.
- The live-refresh throttling (`refreshFromLiveSource`) has been verified via code review and an offline analysis of the bbox-snapping logic, but not yet via a live browser session counting actual Overpass requests — flagging this so a reviewer can spot-check it if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Water-source data now loads faster and more reliably, including during peak usage.
  * Added “Data as of” information to show dataset freshness.
  * Improved identification/sharing and interactions for different map feature types.
  * Offline area downloads now use streamlined single-step water-source loading with smoother progress.

* **Bug Fixes**
  * Fixed marker selection, navigation, image loading, and pump calculations for non-node feature types.
  * Improved offline data reconciliation to prevent premature/incorrect deletions.
  * Updated offline progress messaging to remove chunk counter details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->