### PR TITLE
feat(images): add Panoramax as a marker photo source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ FireYak is a hybrid mobile and web application designed for firefighters and eme
 - **Data Source**: OpenStreetMap via Overpass API (with a native Capacitor transport for mobile), address search via Photon
 - **Local Storage**: IndexedDB (via `idb`) for marker caching, offline areas, tiles, and the pending-edits queue; Capacitor Preferences for settings
 - **Internationalization**: vue-i18n (English + German)
-- **Image Gallery**: PhotoSwipe (for Wikimedia Commons images)
+- **Image Gallery**: PhotoSwipe (Wikimedia Commons and Panoramax images)
 - **Elevation Data**: Mapterhorn terrain DEM tiles (same offline-capable pipeline as the map), used for pump calculation and routing
 - **OSM Editing**: osm-api with OAuth2 PKCE; edits queue offline and sync when back online
 - **In-App Review**: `@capacitor-community/in-app-review`, gated by a usage-based composable
@@ -107,7 +107,7 @@ src/
 | `databaseHandler.ts` | IndexedDB wrapper for marker caching, offline areas, pending edits, and spatial queries |
 | `gridRouting.ts` | Cost-grid Dijkstra terrain routing for hose laying (not clamped to roads, avoids buildings) |
 | `markerHandler.ts` | Creates MapLibre markers with type-specific icons, manages cache |
-| `markerImageHandler.ts` | Fetches Wikimedia Commons images for OSM nodes |
+| `markerImageHandler.ts` | Fetches marker photos from Wikimedia Commons and Panoramax |
 | `nearbyRouting.ts` | Road-aware ranking for the nearby water sources list (routed distance → weighted heuristic → straight-line) |
 | `obstacleGeometry.ts` | Decodes building footprints and road centerlines from Protomaps vector tiles for routing |
 | `overPassApi.ts` | Queries Overpass API (web fetch or native transport) for emergency infrastructure within bounds |

--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ Changes are uploaded immediately and include a changeset comment referencing Fir
 
 ### Photos
 
-If photos exist on Wikimedia Commons using the naming pattern
-`Fire-fighting-facility node-<OSM_ID>`, FireYak shows them in a full-screen gallery for the selected marker.
+FireYak shows photos of the selected marker in a full-screen gallery, collected from:
+
+- **Wikimedia Commons** — files named after the pattern `Fire-fighting-facility node-<OSM_ID>`
+- **Panoramax** — the picture referenced by the marker's `panoramax` tag
+
+Each photo is labelled with its source and links back to the original.
 
 ### Nearby water sources
 
@@ -132,7 +136,7 @@ Configuration:
 | Mobile | Capacitor (iOS + Android) |
 | OSM editing | osm-api (OAuth2 PKCE) |
 | Elevation | Open-Meteo API |
-| Image gallery | PhotoSwipe (Wikimedia Commons) |
+| Image gallery | PhotoSwipe (Wikimedia Commons, Panoramax) |
 | CI/CD | GitHub Actions + Fastlane |
 
 ## Development

--- a/src/assets/whats-new.json
+++ b/src/assets/whats-new.json
@@ -1,5 +1,11 @@
 {
-	"unreleased": [],
+	"unreleased": [
+		{
+			"type": "feature",
+			"en": "Photos of a water source can now also come from Panoramax, not just Wikimedia Commons. Each photo shows its source and links back to the original.",
+			"de": "Fotos einer Wasserentnahmestelle können jetzt auch von Panoramax stammen, nicht nur von Wikimedia Commons. Jedes Foto zeigt seine Quelle und verlinkt zum Original."
+		}
+	],
 	"releases": [
 		{
 			"version": "2.17.0",

--- a/src/assets/whats-new.json
+++ b/src/assets/whats-new.json
@@ -2,8 +2,8 @@
 	"unreleased": [
 		{
 			"type": "feature",
-			"en": "Photos of a water source can now also come from Panoramax, not just Wikimedia Commons. Each photo shows its source and links back to the original.",
-			"de": "Fotos einer Wasserentnahmestelle können jetzt auch von Panoramax stammen, nicht nur von Wikimedia Commons. Jedes Foto zeigt seine Quelle und verlinkt zum Original."
+			"en": "Photos of a water source can now also come from Panoramax, each labelled with its source and linked to the original.",
+			"de": "Fotos einer Wasserentnahmestelle können jetzt auch von Panoramax stammen – mit Quellenangabe und Link zum Original."
 		}
 	],
 	"releases": [

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -111,6 +111,10 @@
 			"loading": "Lade Marker-Informationen...",
 			"dataUpdated": "Daten aktualisiert {time}",
 			"photosOfflineHint": "Fotos sind offline nicht verfügbar."
+		},
+		"images": {
+			"alt": "Foto der Wasserentnahmestelle",
+			"viewOnSource": "Auf {source} ansehen ↗"
 		}
 	},
 	"about": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,6 +111,10 @@
 			"loading": "Loading marker information...",
 			"dataUpdated": "Data updated {time}",
 			"photosOfflineHint": "Photos are unavailable offline."
+		},
+		"images": {
+			"alt": "Water source photo",
+			"viewOnSource": "View on {source} ↗"
 		}
 	},
 	"about": {

--- a/src/mapHandler/markerImageHandler.ts
+++ b/src/mapHandler/markerImageHandler.ts
@@ -5,8 +5,8 @@ export type ImageSource = 'wikimedia' | 'panoramax';
 
 /**
  * One photo, normalised across every provider. Wikimedia Commons is the only
- * source that fills in all of the optional metadata; the street-level sources
- * populate what their APIs return and leave the rest undefined.
+ * source that fills in all of the optional metadata; Panoramax populates what
+ * its API returns and leaves the rest undefined.
  */
 export interface ImageInfo {
 	// Original file details
@@ -29,15 +29,19 @@ export interface ImageInfo {
 
 /**
  * Guards every URL that reaches an `<img src>` or an `<a href>` in the viewer.
- * All three providers hand back URLs we did not construct, and two of them are
- * reached via ids that come straight out of user-editable OSM tags, so a
+ * Both providers hand back URLs we did not construct, and one of them is
+ * reached via an id that comes straight out of a user-editable OSM tag, so a
  * `javascript:` or `data:` URL must never make it through.
+ *
+ * HTTPS only: both APIs serve everything over TLS, so a cleartext URL in a
+ * response is a downgrade rather than a case to support. Dropping it here also
+ * keeps native builds (where the app origin is not itself https) from loading
+ * a photo in the clear.
  */
-function isSafeHttpUrl(url: string | undefined): url is string {
+function isHttpsUrl(url: string | undefined): url is string {
 	if (!url) return false;
 	try {
-		const protocol = new URL(url).protocol;
-		return protocol === 'https:' || protocol === 'http:';
+		return new URL(url).protocol === 'https:';
 	} catch {
 		return false;
 	}
@@ -121,16 +125,16 @@ export async function fetchMediaWikiFiles(ref: OsmRef): Promise<ImageInfo[]> {
 		const images: ImageInfo[] = [];
 		for (const page of Object.values(data.query?.pages ?? {})) {
 			for (const info of page.imageinfo ?? []) {
-				if (!isSafeHttpUrl(info.url)) continue;
+				if (!isHttpsUrl(info.url)) continue;
 				images.push({
 					url: info.url,
 					width: info.width,
 					height: info.height,
-					thumburl: isSafeHttpUrl(info.thumburl) ? info.thumburl : info.url,
+					thumburl: isHttpsUrl(info.thumburl) ? info.thumburl : info.url,
 					thumbwidth: info.thumbwidth,
 					thumbheight: info.thumbheight,
 					source: 'wikimedia',
-					descriptionurl: isSafeHttpUrl(info.descriptionurl) ? info.descriptionurl : undefined,
+					descriptionurl: isHttpsUrl(info.descriptionurl) ? info.descriptionurl : undefined,
 					descriptionshorturl: info.descriptionshorturl,
 					size: info.size,
 					capturedAt: info.timestamp
@@ -197,7 +201,7 @@ export async function fetchPanoramaxImages(panoramaxId: string): Promise<ImageIn
 
 		const feature: PanoramaxFeature = await response.json();
 
-		const fullUrl = [feature.assets?.hd?.href, feature.assets?.sd?.href].find(isSafeHttpUrl);
+		const fullUrl = [feature.assets?.hd?.href, feature.assets?.sd?.href].find(isHttpsUrl);
 		if (!fullUrl) return [];
 
 		const thumbUrl = feature.assets?.thumb?.href;
@@ -208,7 +212,7 @@ export async function fetchPanoramaxImages(panoramaxId: string): Promise<ImageIn
 				// Unknown until the image is loaded — see the doc comment above.
 				width: 0,
 				height: 0,
-				thumburl: isSafeHttpUrl(thumbUrl) ? thumbUrl : fullUrl,
+				thumburl: isHttpsUrl(thumbUrl) ? thumbUrl : fullUrl,
 				thumbwidth: 200,
 				thumbheight: 150,
 				source: 'panoramax',

--- a/src/mapHandler/markerImageHandler.ts
+++ b/src/mapHandler/markerImageHandler.ts
@@ -1,27 +1,73 @@
 import { OsmRef, parseRef } from '@/helper/osmRef';
 
-// The MediaWiki API structure
+/** The photo providers FireYak can pull marker images from. */
+export type ImageSource = 'wikimedia' | 'panoramax';
+
+/**
+ * One photo, normalised across every provider. Wikimedia Commons is the only
+ * source that fills in all of the optional metadata; the street-level sources
+ * populate what their APIs return and leave the rest undefined.
+ */
 export interface ImageInfo {
 	// Original file details
+	url: string;
+	width: number;
+	height: number;
+	// Thumbnail details
+	thumburl: string;
+	thumbwidth: number;
+	thumbheight: number;
+	/** Which provider this photo came from — drives the badge in the viewer. */
+	source: ImageSource;
+	/** Public page for the photo, shown as an attribution link in the viewer. */
+	descriptionurl?: string;
+	descriptionshorturl?: string;
+	size?: number;
+	/** ISO 8601 capture / upload date, used to sort newest-first within a source. */
+	capturedAt?: string;
+}
+
+/**
+ * Guards every URL that reaches an `<img src>` or an `<a href>` in the viewer.
+ * All three providers hand back URLs we did not construct, and two of them are
+ * reached via ids that come straight out of user-editable OSM tags, so a
+ * `javascript:` or `data:` URL must never make it through.
+ */
+function isSafeHttpUrl(url: string | undefined): url is string {
+	if (!url) return false;
+	try {
+		const protocol = new URL(url).protocol;
+		return protocol === 'https:' || protocol === 'http:';
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MediaWiki / Wikimedia Commons
+// ---------------------------------------------------------------------------
+
+interface WikiImageInfo {
 	url: string;
 	size: number;
 	width: number;
 	height: number;
 	descriptionshorturl: string;
 	descriptionurl: string;
-	// Thumbnail details
 	thumburl: string;
 	thumbwidth: number;
 	thumbheight: number;
+	/** ISO 8601 upload timestamp (requested via `iiprop=…|timestamp`). */
+	timestamp?: string;
 }
 
-export interface WikiPage {
+interface WikiPage {
 	pageid: number;
 	title: string;
-	imageinfo: ImageInfo[];
+	imageinfo?: WikiImageInfo[];
 }
 
-interface ApiResponse {
+interface WikiApiResponse {
 	query?: {
 		pages: {
 			[key: string]: WikiPage; // Keys are page IDs
@@ -34,17 +80,17 @@ interface ApiResponse {
 }
 
 /**
- * Fetches a list of files from MediaWiki Commons matching a specific prefix
- * and retrieves image information, including a thumbnail of the specified width.
+ * Fetches files from MediaWiki Commons matching the FireYak naming convention
+ * and retrieves image information, including a thumbnail of a fixed width.
  *
  * The Commons category convention (`Fire-fighting-facility node-<id>`) is
  * node-only — there is no equivalent for ways — so this skips the request
  * entirely for a way ref rather than querying a category that cannot exist.
  *
- * @returns A promise that resolves to an array of file objects.
- * @param ref
+ * @param ref The marker's namespaced OSM ref.
+ * @returns A promise that resolves to the photos found, or `[]` on any failure.
  */
-export async function fetchMediaWikiFiles(ref: OsmRef): Promise<WikiPage[]> {
+export async function fetchMediaWikiFiles(ref: OsmRef): Promise<ImageInfo[]> {
 	const parsed = parseRef(ref);
 	if (parsed?.type !== 'node') {
 		return [];
@@ -56,7 +102,7 @@ export async function fetchMediaWikiFiles(ref: OsmRef): Promise<WikiPage[]> {
 	const thumbnailWidth = 200;
 
 	// Construct the full URL with all necessary parameters
-	const url = `${apiUrl}?action=query&format=json&generator=allpages&gapnamespace=6&gapprefix=${encodedPrefix}&prop=imageinfo&iiprop=url|size|dimensions|mime|thumburl&iiurlwidth=${thumbnailWidth}&gaplimit=10&origin=*`;
+	const url = `${apiUrl}?action=query&format=json&generator=allpages&gapnamespace=6&gapprefix=${encodedPrefix}&prop=imageinfo&iiprop=url|size|dimensions|mime|thumburl|timestamp&iiurlwidth=${thumbnailWidth}&gaplimit=10&origin=*`;
 
 	try {
 		const response = await fetch(url);
@@ -65,21 +111,113 @@ export async function fetchMediaWikiFiles(ref: OsmRef): Promise<WikiPage[]> {
 			throw new Error(`HTTP error! status: ${response.status}`);
 		}
 
-		const data: ApiResponse = await response.json();
+		const data: WikiApiResponse = await response.json();
 
 		if (data.error) {
 			throw new Error(`MediaWiki API error: ${data.error.info}`);
 		}
 
-		// Process the complex 'pages' object into a clean array
-		if (data.query?.pages) {
-			return Object.values(data.query.pages);
+		// Flatten the complex 'pages' object into normalised photo entries
+		const images: ImageInfo[] = [];
+		for (const page of Object.values(data.query?.pages ?? {})) {
+			for (const info of page.imageinfo ?? []) {
+				if (!isSafeHttpUrl(info.url)) continue;
+				images.push({
+					url: info.url,
+					width: info.width,
+					height: info.height,
+					thumburl: isSafeHttpUrl(info.thumburl) ? info.thumburl : info.url,
+					thumbwidth: info.thumbwidth,
+					thumbheight: info.thumbheight,
+					source: 'wikimedia',
+					descriptionurl: isSafeHttpUrl(info.descriptionurl) ? info.descriptionurl : undefined,
+					descriptionshorturl: info.descriptionshorturl,
+					size: info.size,
+					capturedAt: info.timestamp
+				});
+			}
 		}
-
-		// Return an empty array if no files were found
-		return [];
+		return images;
 	} catch (error) {
 		console.error('Error fetching MediaWiki data:', error);
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Panoramax
+// ---------------------------------------------------------------------------
+
+const PANORAMAX_API = 'https://api.panoramax.xyz';
+
+/**
+ * The `panoramax` OSM tag holds a picture UUID. Anything else — a sequence id,
+ * a full URL, a typo — cannot be resolved by the pictures endpoint, so it is
+ * rejected before a request is made rather than after a 404. This doubles as
+ * the sanitiser for the two places the id is interpolated into a URL.
+ */
+const PANORAMAX_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A Panoramax picture as returned by the API (a STAC Item). */
+interface PanoramaxFeature {
+	type: 'Feature';
+	id: string;
+	properties?: {
+		datetime?: string;
+		[key: string]: unknown;
+	};
+	assets?: {
+		hd?: { href?: string };
+		sd?: { href?: string };
+		thumb?: { href?: string };
+	};
+}
+
+/**
+ * Fetches a single picture from the Panoramax API by the UUID stored in the
+ * OSM `panoramax` tag.
+ *
+ * Panoramax does not report pixel dimensions on the picture item, so `width`
+ * and `height` are left at 0; the viewer resolves them by preloading the image
+ * before it hands the slide to PhotoSwipe.
+ */
+export async function fetchPanoramaxImages(panoramaxId: string): Promise<ImageInfo[]> {
+	if (!PANORAMAX_ID_PATTERN.test(panoramaxId)) {
+		return [];
+	}
+
+	try {
+		const response = await fetch(`${PANORAMAX_API}/api/pictures/${panoramaxId}`);
+
+		if (!response.ok) {
+			// 404 means the id doesn't exist on this instance — skip silently
+			if (response.status === 404) return [];
+			throw new Error(`Panoramax API HTTP error: ${response.status}`);
+		}
+
+		const feature: PanoramaxFeature = await response.json();
+
+		const fullUrl = [feature.assets?.hd?.href, feature.assets?.sd?.href].find(isSafeHttpUrl);
+		if (!fullUrl) return [];
+
+		const thumbUrl = feature.assets?.thumb?.href;
+
+		return [
+			{
+				url: fullUrl,
+				// Unknown until the image is loaded — see the doc comment above.
+				width: 0,
+				height: 0,
+				thumburl: isSafeHttpUrl(thumbUrl) ? thumbUrl : fullUrl,
+				thumbwidth: 200,
+				thumbheight: 150,
+				source: 'panoramax',
+				descriptionurl: `${PANORAMAX_API}/#focus=pic&pic=${panoramaxId}`,
+				capturedAt: feature.properties?.datetime
+			}
+		];
+	} catch (error) {
+		console.error('Error fetching Panoramax data:', error);
 		return [];
 	}
 }

--- a/src/store/mapMarkerStore.ts
+++ b/src/store/mapMarkerStore.ts
@@ -4,7 +4,12 @@ import { ref } from 'vue';
 import { OverPassElement } from '@/mapHandler/overPassApi';
 import { fetchElementById } from '@/mapHandler/overPassApi';
 import { CachedMapNode, getMapNodeById, storeMapNodes } from '@/mapHandler/databaseHandler';
-import { fetchMediaWikiFiles, ImageInfo } from '@/mapHandler/markerImageHandler';
+import {
+	fetchMediaWikiFiles,
+	fetchPanoramaxImages,
+	ImageInfo,
+	ImageSource
+} from '@/mapHandler/markerImageHandler';
 import { useNetworkStatus } from '@/composable/networkStatus';
 import { OsmRef, parseRef, toRef } from '@/helper/osmRef';
 
@@ -60,20 +65,67 @@ export const useMapMarkerStore = defineStore('marker', () => {
 		return fetchPromise;
 	}
 
-	async function fetchMarkerImageInfoById(ref: OsmRef) {
-		// Photo galleries (Wikimedia Commons) need a connection — skip the
-		// request entirely while offline instead of letting it fail.
+	/**
+	 * Order the photo sources are shown in. Street-level captures are usually
+	 * the most recent view of a water source, so they lead; the curated Commons
+	 * uploads come last. The first entry is also what {@link MarkerInfoPanel}
+	 * uses as the thumbnail, so this ordering decides that too.
+	 */
+	const sourcePriority: Record<ImageSource, number> = {
+		panoramax: 0,
+		wikimedia: 1
+	};
+
+	/**
+	 * Fetches photos for a marker from every configured source in parallel:
+	 * - Wikimedia Commons, matched by the OSM node id
+	 * - Panoramax, from the `panoramax` tag
+	 *
+	 * @param ref  The marker's namespaced OSM ref.
+	 * @param tags The marker's OSM tags. Resolved from the cache/selection when
+	 *             omitted, so callers that only hold a ref (the image viewer
+	 *             opened from a deep link) still get the tagged sources.
+	 */
+	async function fetchMarkerImageInfoById(
+		ref: OsmRef,
+		tags?: Record<string, string>
+	): Promise<ImageInfo[]> {
+		// Photo galleries need a connection — skip the requests entirely while
+		// offline instead of letting them fail.
 		const { isOnline } = useNetworkStatus();
 		if (!isOnline.value) {
 			selectedMarkerImages.value = [];
 			return [];
 		}
 
-		const imageData = await fetchMediaWikiFiles(ref);
-		const imageDataList: ImageInfo[] = [];
-		imageData.forEach((image) => {
-			imageDataList.push(...image.imageinfo);
+		const markerTags =
+			tags ??
+			(selectedMarker.value?.ref === ref
+				? selectedMarker.value.tags
+				: (await fetchMarkerById(ref))?.tags);
+
+		const requests: Promise<ImageInfo[]>[] = [fetchMediaWikiFiles(ref)];
+
+		if (markerTags?.panoramax) {
+			requests.push(fetchPanoramaxImages(markerTags.panoramax));
+		}
+
+		// Every fetcher already swallows its own errors, but settling keeps one
+		// unexpected rejection from dropping the photos of the other sources.
+		const results = await Promise.allSettled(requests);
+		const imageDataList = results.flatMap((result) =>
+			result.status === 'fulfilled' ? result.value : []
+		);
+
+		imageDataList.sort((a, b) => {
+			const priorityDiff = sourcePriority[a.source] - sourcePriority[b.source];
+			if (priorityDiff !== 0) return priorityDiff;
+			// Same source: newest first, undated entries last
+			const aTime = a.capturedAt ? Date.parse(a.capturedAt) : 0;
+			const bTime = b.capturedAt ? Date.parse(b.capturedAt) : 0;
+			return (bTime || 0) - (aTime || 0);
 		});
+
 		selectedMarkerImages.value = imageDataList;
 		return imageDataList;
 	}
@@ -87,7 +139,9 @@ export const useMapMarkerStore = defineStore('marker', () => {
 			const marker = await fetchMarkerById(ref);
 			if (marker) {
 				selectedMarker.value = marker;
-				fetchMarkerImageInfoById(ref);
+				// Pass the tags we already hold so the Panoramax id doesn't cost
+				// a second marker lookup.
+				fetchMarkerImageInfoById(ref, marker.tags);
 			}
 		}
 	}

--- a/src/views/MarkerImageViewer.vue
+++ b/src/views/MarkerImageViewer.vue
@@ -20,20 +20,54 @@ import { useIonRouter } from '@ionic/vue';
 import { IonButton, IonContent, IonIcon, IonPage } from '@ionic/vue';
 import { cloudOfflineOutline } from 'ionicons/icons';
 import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 // PhotoSwipe imports
 import PhotoSwipeLightbox from 'photoswipe/lightbox';
+import type PhotoSwipe from 'photoswipe';
 import 'photoswipe/photoswipe.css';
 import { useMapMarkerStore } from '@/store/mapMarkerStore';
+import type { ImageSource } from '@/mapHandler/markerImageHandler';
 import { useNetworkStatus } from '@/composable/networkStatus';
 import { coerceRef } from '@/helper/osmRef';
 
 const ionRouter = useIonRouter();
 const route = useRoute();
+const { t } = useI18n();
 const { selectedMarkerImages, fetchMarkerImageInfoById } = useMapMarkerStore();
 const { isOnline } = useNetworkStatus();
 
 const lightbox = ref<PhotoSwipeLightbox | null>(null);
+
+/** Badge colour per provider. Names are trademarks, so they stay untranslated. */
+const sourceColor: Record<ImageSource, string> = {
+	wikimedia: '#006699',
+	panoramax: '#2a7a2a'
+};
+
+const sourceLabel: Record<ImageSource, string> = {
+	wikimedia: 'Wikimedia Commons',
+	panoramax: 'Panoramax'
+};
+
+/** Extra per-slide data carried through PhotoSwipe for the attribution badge. */
+interface SlideAttribution {
+	source?: ImageSource;
+	descriptionUrl?: string;
+}
+
+/**
+ * Aspect ratio used when an image's real size can't be determined — either the
+ * provider doesn't report one and the preload failed, or it took too long.
+ */
+const FALLBACK_SIZE = { width: 1920, height: 1080 };
+
+/**
+ * Panoramax doesn't report pixel dimensions, and PhotoSwipe needs them upfront
+ * to lay a slide out. Waiting on the full-size image is the only way to learn
+ * them, so it is capped: a stalled CDN must not hold the gallery closed.
+ */
+const PRELOAD_TIMEOUT_MS = 4000;
 
 // Function to handle gallery close event, navigating back
 const handleClose = () => {
@@ -42,6 +76,55 @@ const handleClose = () => {
 	} else {
 		ionRouter.replace(`/markers/${route.params.relatedId}`);
 	}
+};
+
+/** Resolves an image's natural dimensions, falling back after a timeout. */
+const resolveImageSize = (src: string): Promise<{ width: number; height: number }> =>
+	new Promise((resolve) => {
+		const img = new Image();
+		const timer = setTimeout(() => {
+			img.onload = img.onerror = null;
+			resolve(FALLBACK_SIZE);
+		}, PRELOAD_TIMEOUT_MS);
+		const settle = (size: { width: number; height: number }) => {
+			clearTimeout(timer);
+			resolve(size);
+		};
+		img.onload = () => settle({ width: img.naturalWidth, height: img.naturalHeight });
+		img.onerror = () => settle(FALLBACK_SIZE);
+		img.src = src;
+	});
+
+/**
+ * Builds the attribution badge for the active slide. Everything is set through
+ * DOM APIs rather than `innerHTML`: the description URL of a street-level photo
+ * derives from a user-editable OSM tag, so it must never be parsed as markup.
+ */
+const renderBadge = (el: HTMLElement, slide: SlideAttribution | undefined) => {
+	el.replaceChildren();
+
+	if (!slide?.source) {
+		el.style.display = 'none';
+		return;
+	}
+
+	const badge = document.createElement('span');
+	badge.className = 'pswp-source-badge';
+	badge.style.background = sourceColor[slide.source];
+	badge.textContent = sourceLabel[slide.source];
+	el.append(badge);
+
+	if (slide.descriptionUrl) {
+		const link = document.createElement('a');
+		link.className = 'pswp-source-link';
+		link.href = slide.descriptionUrl;
+		link.target = '_blank';
+		link.rel = 'noopener noreferrer';
+		link.textContent = t('markerInfo.images.viewOnSource', { source: sourceLabel[slide.source] });
+		el.append(link);
+	}
+
+	el.style.display = 'flex';
 };
 
 onMounted(async () => {
@@ -60,21 +143,46 @@ onMounted(async () => {
 		}
 	}
 
-	// Map fetched image data to PhotoSwipe item format
-	const pswpItems = markerImages.map((image) => {
-		return {
-			src: image.url,
-			width: image.width, // Placeholder width
-			height: image.height, // Placeholder height
-			alt: 'Hydrant image' // Use title if available, otherwise a generic alt
-		};
-	});
+	// Map fetched image data to PhotoSwipe item format. Sources that report
+	// their dimensions are used as-is; the rest are preloaded so PhotoSwipe
+	// gets a real aspect ratio instead of stretching the slide.
+	const pswpItems = await Promise.all(
+		markerImages.map(async (image) => {
+			const { width, height } =
+				image.width > 0 && image.height > 0 ? image : await resolveImageSize(image.url);
+
+			return {
+				src: image.url,
+				width,
+				height,
+				alt: t('markerInfo.images.alt'),
+				source: image.source,
+				descriptionUrl: image.descriptionurl
+			};
+		})
+	);
 
 	lightbox.value = new PhotoSwipeLightbox({
 		gallery: '#container',
 		dataSource: pswpItems,
 		pswpModule: () => import('photoswipe'),
 		clickToCloseNonZoomable: false
+	});
+
+	// Attribution badge, kept in sync with whichever slide is showing
+	lightbox.value.on('uiRegister', () => {
+		lightbox.value?.pswp?.ui?.registerElement({
+			name: 'source-badge',
+			order: 9,
+			isButton: false,
+			appendTo: 'wrapper',
+			onInit: (el: HTMLElement, pswp: PhotoSwipe) => {
+				el.style.display = 'none';
+				const update = () => renderBadge(el, pswp.currSlide?.data as SlideAttribution | undefined);
+				pswp.on('change', update);
+				update();
+			}
+		});
 	});
 
 	// Add a close event listener to navigate back
@@ -115,5 +223,45 @@ onUnmounted(() => {
 .offline-photos-icon {
 	font-size: 40px;
 	color: var(--md-sys-on-surface-variant);
+}
+
+/* Source badge — PhotoSwipe derives the class from registerElement's `name` */
+.pswp__source-badge {
+	position: absolute;
+	bottom: calc(var(--ion-safe-area-bottom, 0px) + 60px);
+	left: 12px;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 4px;
+	pointer-events: auto;
+	z-index: 200;
+}
+
+.pswp-source-badge {
+	display: inline-block;
+	padding: 4px 10px;
+	border-radius: 12px;
+	color: #fff;
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	opacity: 0.9;
+}
+
+.pswp-source-link {
+	display: inline-block;
+	padding: 3px 8px;
+	border-radius: 8px;
+	background: rgba(0, 0, 0, 0.55);
+	color: #fff;
+	font-size: 0.7rem;
+	text-decoration: none;
+	opacity: 0.85;
+}
+
+.pswp-source-link:hover {
+	opacity: 1;
+	text-decoration: underline;
 }
 </style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -163,6 +163,38 @@ const pwaOptions: Partial<VitePWAOptions> = {
 						statuses: [0, 200]
 					}
 				}
+			},
+			{
+				// Panoramax serves picture bytes under the picture id
+				// (`…/pictures/<uuid>/hd.jpg`). They are immutable, so cache them
+				// outright — this rule must precede the metadata rule below, which
+				// would otherwise re-download every photo in the background.
+				urlPattern: /^https?:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+\/.+/,
+				handler: 'CacheFirst',
+				options: {
+					cacheName: 'panoramax-images-cache',
+					expiration: {
+						maxEntries: 200,
+						maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
+					},
+					cacheableResponse: {
+						statuses: [0, 200]
+					}
+				}
+			},
+			{
+				urlPattern: /^https?:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+$/,
+				handler: 'StaleWhileRevalidate',
+				options: {
+					cacheName: 'panoramax-api-cache',
+					expiration: {
+						maxEntries: 100,
+						maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+					},
+					cacheableResponse: {
+						statuses: [0, 200]
+					}
+				}
 			}
 		]
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -169,7 +169,7 @@ const pwaOptions: Partial<VitePWAOptions> = {
 				// (`…/pictures/<uuid>/hd.jpg`). They are immutable, so cache them
 				// outright — this rule must precede the metadata rule below, which
 				// would otherwise re-download every photo in the background.
-				urlPattern: /^https?:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+\/.+/,
+				urlPattern: /^https:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+\/.+/,
 				handler: 'CacheFirst',
 				options: {
 					cacheName: 'panoramax-images-cache',
@@ -183,7 +183,7 @@ const pwaOptions: Partial<VitePWAOptions> = {
 				}
 			},
 			{
-				urlPattern: /^https?:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+$/,
+				urlPattern: /^https:\/\/api\.panoramax\.xyz\/api\/pictures\/[^/]+$/,
 				handler: 'StaleWhileRevalidate',
 				options: {
 					cacheName: 'panoramax-api-cache',


### PR DESCRIPTION
## Summary

Marker photos are now collected from **Wikimedia Commons and Panoramax** in parallel, normalised into a single `ImageInfo` shape and sorted by source, then by capture date. Each slide in the gallery is labelled with its provider and links back to the original.

This supersedes #76 (`feature/display-other-images-sources`), which was 112 commits behind `main` and touched only files that `main` had since rewritten. Rather than a mechanical rebase, the feature was re-applied on top of current `main` and squashed — its three commits were a feature plus a fix and a partial revert of itself.

## Type of change

- [x] ✨ New feature (`feat:`)
- [x] 📖 Documentation

## Key changes

### Rebase onto current `main`

Two things landed on `main` that this feature had to absorb:

- **Namespaced `OsmRef` marker keys** — `fetchMediaWikiFiles` and `fetchMarkerImageInfoById` both take a ref now, and the Commons lookup keeps its node-only guard (the `Fire-fighting-facility node-<id>` convention has no way/relation equivalent).
- **Offline handling** — the photo fetch still short-circuits when offline, and the viewer keeps its offline hint instead of an empty gallery.

### Fixes applied on top of the original branch

- **Injection via OSM tag data.** The attribution badge was built with `innerHTML`, and the Panoramax description URL was interpolated from the raw `panoramax=*` tag with no encoding — any OSM editor could inject markup into the viewer. The badge is now built with DOM APIs, the tag value is validated against a UUID pattern before it reaches a URL, and every provider-supplied URL is checked for an `http(s)` scheme before it reaches an `src` or `href`.
- **Unbounded preload.** Panoramax reports no pixel dimensions, so the images were preloaded with `await Promise.all(...)` before the lightbox opened — one stalled response and the gallery never opens. Now capped at 4s per image with a 1920×1080 fallback.
- **Hardcoded English** labels, link text and alt text moved into `en.json` / `de.json` as `markerInfo.images.*`. Provider names stay untranslated as trademarks.
- **Service worker caching.** Picture bytes are cached cache-first, metadata stale-while-revalidate — previously one SWR rule covered both, which re-downloaded every photo in the background on each view.

### Mapillary deliberately excluded

The original branch also added Mapillary. Its Graph API requires an access token for every request, and the image URLs it returns are signed and expiring, so there is no tokenless way to render a Mapillary photo as a gallery slide. The tokenless alternative — a `mapillary.com/embed` iframe — was implemented and then removed on the original branch, and is not revived here: it carries no thumbnail, no dimensions, no zoom, and cannot be cached offline. All Mapillary code, config, env wiring and docs are absent from this PR.

## How was it tested?

- [ ] Web (`npm run dev` / built bundle)
- [ ] Android (device or emulator)
- [ ] iOS (device or simulator)

**Not verified at runtime.** `npm run build`, `vue-tsc` and `eslint .` all pass, and the generated `dist/sw.js` was checked to confirm the two new Workbox routes register in the right precedence order. But the gallery itself was never exercised against the live APIs — outbound network in the authoring environment is restricted to an allowlist that excludes `api.panoramax.xyz` and `commons.wikimedia.org`.

Two consequences worth a reviewer's attention:

1. **The Panoramax response shape is unverified.** The `assets.hd/sd/thumb` hrefs and `properties.datetime` field names are inherited from the original branch and were never confirmed against a real response. The code tolerates any of them being absent (it returns `[]` rather than throwing), so the failure mode is "no Panoramax photo" rather than a crash — but if the field names are wrong, the feature silently does nothing.
2. **No screenshots**, for the same reason — the gallery cannot be made to render a real photo here.

Please open a marker tagged `panoramax=<uuid>` on a real build before merging.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run build` and lint pass locally
- [x] New user-facing strings added to **both** `src/locales/en.json` and `src/locales/de.json`
- [x] What's New entry added to `src/assets/whats-new.json` (en + de)
- [x] No secrets, API keys, or personal data in the diff
- [ ] Screenshots attached for UI changes — see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGWnt3KDeWuyGWtAH4yG2j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGWnt3KDeWuyGWtAH4yG2j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Panoramax as an additional source for water-source photos.
  * Photo galleries now display source attribution, links to original images, capture dates, and provider badges.
  * Images from multiple sources are combined and prioritized by source and capture date.
* **Bug Fixes**
  * Improved handling of unavailable images, unsafe links, and provider-specific loading errors.
* **Documentation**
  * Updated product and developer documentation to describe Panoramax photo support.
* **Localization**
  * Added English and German translations for photo descriptions and source links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->