### PR TITLE
perf(cache): index cached markers by tile and keep hot tiles in memory

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,22 @@ loadSettings();
 // Number of days a cached water source is kept before it is pruned.
 const CACHE_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
+/** How long housekeeping waits for an idle moment before running anyway. */
+const IDLE_TASK_TIMEOUT_MS = 10_000;
+
+/**
+ * Runs background housekeeping once the main thread has nothing better to do.
+ * Falls back to a plain timeout on engines without `requestIdleCallback`
+ * (notably iOS WebKit, which is exactly where a blocked main thread hurts most).
+ */
+function runWhenIdle(task: () => void): void {
+	if (typeof window.requestIdleCallback === 'function') {
+		window.requestIdleCallback(task, { timeout: IDLE_TASK_TIMEOUT_MS });
+	} else {
+		window.setTimeout(task, IDLE_TASK_TIMEOUT_MS / 2);
+	}
+}
+
 // Track active usage days and auto-prompt for review (one-shot)
 const { recordActiveDay, scheduleAutoPrompt, cancelAutoPrompt } = useInAppReview();
 const { checkForUpdate } = useWhatsNew();
@@ -49,10 +65,15 @@ onOnline(() => {
 });
 
 onMounted(async () => {
-	// Fire-and-forget: drop cache entries older than 90 days so the local
-	// IndexedDB store doesn't grow unboundedly as the user pans around.
-	// Nodes inside a downloaded offline area are exempt from pruning.
-	pruneStaleMapNodes(CACHE_MAX_AGE_MS);
+	// Drop cache entries older than 90 days so the local IndexedDB store doesn't
+	// grow unboundedly as the user pans around. Nodes inside a downloaded offline
+	// area are exempt from pruning.
+	//
+	// Deferred to idle rather than run here: the prune deletes in `readwrite`
+	// transactions, which take an exclusive lock on the marker store, and the map
+	// mounts at the same moment and immediately reads it. Started eagerly, the
+	// very first viewport read waits on the prune.
+	runWhenIdle(() => void pruneStaleMapNodes(CACHE_MAX_AGE_MS));
 
 	// Fire-and-forget: hydrate the offline-areas store (also triggers auto-refresh).
 	offlineAreasStore.init();

--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -525,7 +525,19 @@ function getMapBounds(): GeoBounds | null {
 	};
 }
 
-async function handleMapMovement() {
+/** Monotonic id per {@link handleMapMovement} call, used to order renders. */
+let moveSequence = 0;
+/** Sequence of the most recent render that actually reached `setData`. */
+let lastRenderedSequence = 0;
+/**
+ * Aborts the fetch belonging to the view the *next* map movement replaces. Only
+ * movement-driven renders arm it — a re-render triggered by a filter change or
+ * a finished background refresh must never cancel a load that is still on its
+ * way, or the map would be left empty until the user pans again.
+ */
+let pendingMoveFetch: AbortController | null = null;
+
+async function handleMapMovement(options: { supersedes?: boolean } = {}) {
 	// do not fetch data for big zoom areas!
 	if (!rootMap || rootMap.getZoom() <= 9) return;
 
@@ -534,8 +546,22 @@ async function handleMapMovement() {
 		return;
 	}
 
-	const geojson = await getMarkersForView(bounds);
-	const source = rootMap.getSource(MARKER_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+	const controller = new AbortController();
+	if (options.supersedes) {
+		pendingMoveFetch?.abort();
+		pendingMoveFetch = controller;
+	}
+	const sequence = ++moveSequence;
+
+	const geojson = await getMarkersForView(bounds, controller.signal);
+
+	// Superseded by a newer movement, or overtaken by a render that started
+	// later and already landed — either way this frame is stale.
+	if (controller.signal.aborted || sequence < lastRenderedSequence) return;
+	if (pendingMoveFetch === controller) pendingMoveFetch = null;
+	lastRenderedSequence = sequence;
+
+	const source = rootMap?.getSource(MARKER_SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
 	if (source) {
 		source.setData(geojson);
 	}
@@ -804,7 +830,9 @@ watch(pumpCalculation.calculationResult, (val) => {
 	}
 });
 
-const debouncedMapMove = debounce(handleMapMovement, MOVE_DEBOUNCE_MS);
+// Only the movement path supersedes: a new viewport makes any load still
+// running for the previous one dead weight.
+const debouncedMapMove = debounce(() => handleMapMovement({ supersedes: true }), MOVE_DEBOUNCE_MS);
 
 // ---------------------------------------------------------------------------
 // Fetch-error toast (§1.5)

--- a/src/helper/tileMath.ts
+++ b/src/helper/tileMath.ts
@@ -1,10 +1,12 @@
 /**
  * Minimal Web-Mercator slippy-tile helpers.
  *
- * Only what the freshness registry (§1.4) needs today — a fuller version
- * (tile-range enumeration, tile → bounds, etc.) arrives with the offline-mode
- * area download.
+ * Used by the marker freshness registry (§1.4) and by the IndexedDB marker
+ * cache, whose rows carry a tile key so a viewport read can be answered from a
+ * handful of index lookups instead of a scan.
  */
+
+import { GeoBounds } from '@/types/geo';
 
 export interface TileCoord {
 	z: number;
@@ -29,4 +31,36 @@ export function lngLatToTile(lat: number, lng: number, z: number): TileCoord {
 /** Stable string key for a tile, e.g. `"12/2200/1416"`. */
 export function tileKey(tile: TileCoord): string {
 	return `${tile.z}/${tile.x}/${tile.y}`;
+}
+
+/**
+ * Every zoom-{@link z} tile overlapping {@link bounds}, as {@link tileKey}
+ * strings.
+ *
+ * Walks the x axis with wrap-around so bounds that cross the antimeridian
+ * (`west > east`, which `boundsContains` accepts too) enumerate the two short
+ * runs either side of ±180° rather than the whole planet the other way round.
+ * The column count is capped at `2 ** z`, so a world-spanning bbox yields each
+ * column exactly once.
+ */
+export function tileKeysForBounds(bounds: GeoBounds, z: number): string[] {
+	const n = 2 ** z;
+	const nw = lngLatToTile(bounds.north, bounds.west, z);
+	const se = lngLatToTile(bounds.south, bounds.east, z);
+
+	// y grows southward, so `north` maps to the smaller index — but the caller's
+	// bounds are not guaranteed to be normalized, hence min/max rather than a
+	// straight nw.y → se.y walk.
+	const yStart = Math.min(nw.y, se.y);
+	const yEnd = Math.max(nw.y, se.y);
+	const columns = Math.min(n, ((se.x - nw.x + n) % n) + 1);
+
+	const keys: string[] = [];
+	for (let i = 0; i < columns; i++) {
+		const x = (nw.x + i) % n;
+		for (let y = yStart; y <= yEnd; y++) {
+			keys.push(tileKey({ z, x, y }));
+		}
+	}
+	return keys;
 }

--- a/src/mapHandler/databaseHandler.ts
+++ b/src/mapHandler/databaseHandler.ts
@@ -425,11 +425,16 @@ async function readTilesFromDb(keys: string[]): Promise<Map<string, CachedMapNod
 
 /** Returns every cached node in the given tiles, reading the missing ones. */
 async function getTiles(keys: string[], attempt = 0): Promise<CachedMapNode[]> {
+	// Fenced before the residency check, not inside it: a *resident* tile is
+	// just as stale as a missing one while a write that has not yet reached
+	// `applyStoredNodesToCache` is outstanding. Fencing only the miss path
+	// would let an all-resident read return pre-write rows.
+	await pendingWrites;
+
 	const missing = keys.filter((key) => !tileCache.has(key));
 	let fetched: Map<string, CachedMapNode[]> | null = null;
 
 	if (missing.length > 0) {
-		await pendingWrites;
 		const epoch = cacheEpoch;
 		fetched = await readTilesFromDb(missing);
 
@@ -692,13 +697,35 @@ export async function pruneStaleMapNodes(maxAgeMs: number) {
 
 		// Phase 2 — delete in bounded batches, each its own short transaction, so
 		// a read never waits on more than one batch.
+		//
+		// Every candidate is re-checked inside its write transaction. Splitting
+		// selection from deletion opened a window the single-cursor version did
+		// not have: the prune runs from `runWhenIdle` while the map is loading its
+		// first viewport, and that fetch re-stores exactly the rows most likely to
+		// be 90 days old — the area the user last looked at. Deleting on the phase-1
+		// verdict alone would drop those markers immediately after they arrived,
+		// and the freshness stamp in `markerHandler` would suppress a re-fetch for
+		// the rest of the TTL.
 		for (let i = 0; i < doomed.length; i += PRUNE_BATCH_SIZE) {
 			const batch = doomed.slice(i, i + PRUNE_BATCH_SIZE);
-			const tx = db.transaction(markerStoreName, 'readwrite');
-			await Promise.all([...batch.map((ref) => tx.store.delete(ref)), tx.done]);
+			await trackWrite(
+				(async () => {
+					const tx = db.transaction(markerStoreName, 'readwrite');
+					const rows = (await Promise.all(batch.map((ref) => tx.store.get(ref)))) as (
+						| CachedMapNode
+						| undefined
+					)[];
+					const stillStale = rows.filter(
+						(row): row is CachedMapNode => row !== undefined && (row.fetchedAt ?? 0) < cutoff
+					);
+					await Promise.all([...stillStale.map((row) => tx.store.delete(row.ref)), tx.done]);
+					// Surgical, and tracked: the whole point of running at idle is to
+					// stay out of the map's way, so clearing every resident tile here
+					// would throw away the cache the first render just warmed.
+					forgetRefsInCache(new Set(stillStale.map((row) => row.ref)));
+				})()
+			);
 		}
-
-		clearTileCache();
 	} catch (e) {
 		console.error('Error pruning stale map nodes:', e);
 		clearTileCache();

--- a/src/mapHandler/databaseHandler.ts
+++ b/src/mapHandler/databaseHandler.ts
@@ -2,25 +2,59 @@ import { openDB } from 'idb';
 import { OverPassElement } from '@/mapHandler/overPassApi';
 import { GeoPoint, GeoBounds, distanceTo, boundsContains } from '@/types/geo';
 import { OsmRef, toRef } from '@/helper/osmRef';
+import { lngLatToTile, tileKey, tileKeysForBounds } from '@/helper/tileMath';
 
 const markerStoreName = 'fireMarkerRefs';
+
+/**
+ * Zoom level of the slippy tile each cached node is filed under (DB v5).
+ *
+ * Every viewport read resolves to "which tiles does this bbox touch?" plus one
+ * index lookup per tile, so the zoom trades read count against over-fetch. At
+ * z10 a tile is roughly 27 × 19 km at central-European latitudes — about a
+ * city — which keeps a typical viewport at a handful of lookups while never
+ * pulling in more than a city's worth of rows per lookup.
+ *
+ * This value is baked into the stored `tile` property, so changing it requires
+ * a migration that recomputes every row.
+ */
+export const CACHE_TILE_ZOOM = 10;
 
 /**
  * A node as it lives in the IndexedDB cache: the raw Overpass element plus
  * cache-only bookkeeping (`__deleted` soft-delete flag and the `fetchedAt`
  * timestamp added in DB v2), plus the namespaced {@link OsmRef} that has been
- * the store's keyPath since DB v4 (§4.5). The optional fields let it be used
- * anywhere an {@link OverPassElement} is expected while still exposing
- * `fetchedAt`.
+ * the store's keyPath since DB v4 (§4.5) and the `tile` key added in DB v5.
+ * The optional fields let it be used anywhere an {@link OverPassElement} is
+ * expected while still exposing `fetchedAt`.
  */
 export type CachedMapNode = OverPassElement & {
 	ref: OsmRef;
 	__deleted?: boolean;
 	fetchedAt?: number;
+	/** z{@link CACHE_TILE_ZOOM} {@link tileKey} of the node's position. */
+	tile?: string;
 };
 
 const offlineAreasStoreName = 'offlineAreas';
 const pendingEditsStoreName = 'pendingEdits';
+const deletedRefsStoreName = 'deletedRefs';
+
+/**
+ * A tombstone for a node the user deleted locally (DB v5).
+ *
+ * Before v5 this lived as a `__deleted` flag on the cached node itself, which
+ * meant every single write had to `get` the existing row first just to find out
+ * whether it was carrying one — doubling the request count of a 1000-node
+ * viewport store. Keeping the refs in their own tiny store lets
+ * {@link storeMapNodes} read the whole tombstone set in one request and then
+ * issue nothing but `put`s. The flag is still mirrored onto the node so readers
+ * (and the reconciliation pass) need not join across two stores.
+ */
+interface DeletedRefRecord {
+	ref: OsmRef;
+	deletedAt: number;
+}
 
 /**
  * A pre-downloaded offline area: the geographic bounds plus download bookkeeping.
@@ -116,7 +150,14 @@ function isDeleted(node: unknown): boolean {
 /** Store name used before the DB v4 namespaced-key migration (§4.5). */
 const legacyMarkerStoreName = 'fireMarker';
 
-const dbPromise = openDB('FireMarker', 4, {
+/**
+ * Rows read (and rewritten) per batch by the DB v5 backfill. Small enough that
+ * an upgrade on a large cache never holds thousands of records in memory,
+ * large enough that the writes pipeline instead of paying a round-trip each.
+ */
+const MIGRATION_CHUNK_SIZE = 1000;
+
+const dbPromise = openDB('FireMarker', 5, {
 	async upgrade(db, oldVersion, _newVersion, tx) {
 		if (oldVersion < 1) {
 			// Fresh install: create the store keyed by the node `id`.
@@ -200,6 +241,64 @@ const dbPromise = openDB('FireMarker', 4, {
 				db.deleteObjectStore(legacyMarkerStoreName);
 			}
 		}
+
+		if (oldVersion < 5) {
+			// Tile-keyed reads (see CACHE_TILE_ZOOM). The `lat, lon` index this
+			// replaces is a *compound* index, and `IDBKeyRange.bound([south, west],
+			// [north, east])` over one is lexicographic, not a 2D box: it matches
+			// every row whose latitude falls in the band, at any longitude on the
+			// planet. Reads therefore cost what the whole cache holds at that
+			// latitude rather than what the viewport holds — which is why the map
+			// got slower the more the user had panned around. A plain `tile` index
+			// turns the same query into one exact-match lookup per covered tile.
+			//
+			// `lat, lon` is deliberately kept: `readNodesForBounds` still falls back
+			// to it for bounds too large to enumerate as tiles.
+			const store = tx.objectStore(markerStoreName);
+			if (!store.indexNames.contains('tile')) {
+				store.createIndex('tile', 'tile');
+			}
+
+			// Soft-delete tombstones move out of the node rows — see DeletedRefRecord.
+			const tombstones = db.objectStoreNames.contains(deletedRefsStoreName)
+				? tx.objectStore(deletedRefsStoreName)
+				: db.createObjectStore(deletedRefsStoreName, { keyPath: 'ref' });
+
+			// Backfill `tile` on every existing row, and lift its `__deleted` flag
+			// into the tombstone store. Walked in primary-key order in bounded
+			// batches whose writes are issued together: awaiting each `put` in turn
+			// would make an upgrade on a six-figure cache pay one IndexedDB
+			// round-trip per row, stalling the first launch after the update.
+			const migratedAt = Date.now();
+			let lastRef: OsmRef | undefined;
+			for (;;) {
+				const range = lastRef === undefined ? undefined : IDBKeyRange.lowerBound(lastRef, true);
+				const rows = (await store.getAll(range, MIGRATION_CHUNK_SIZE)) as CachedMapNode[];
+				if (rows.length === 0) break;
+
+				const writes: Promise<unknown>[] = [];
+				for (const row of rows) {
+					if (row.__deleted) {
+						writes.push(tombstones.put({ ref: row.ref, deletedAt: migratedAt }));
+					}
+					const point = getNodePoint(row);
+					// A row without coordinates was already invisible to every reader
+					// (they all resolve a point first), so leaving it untiled changes
+					// nothing except that the prune will eventually collect it.
+					if (!point) continue;
+					writes.push(
+						store.put({
+							...row,
+							tile: tileKey(lngLatToTile(point.lat, point.lng, CACHE_TILE_ZOOM))
+						})
+					);
+				}
+				await Promise.all(writes);
+
+				lastRef = rows[rows.length - 1].ref;
+				if (rows.length < MIGRATION_CHUNK_SIZE) break;
+			}
+		}
 	}
 });
 
@@ -214,70 +313,240 @@ function getNodePoint(node: OverPassElement): GeoPoint | null {
 	return { lat, lng };
 }
 
-export async function storeMapNodes(nodes: OverPassElement[]) {
-	try {
-		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
-		const fetchedAt = Date.now();
-		await Promise.all([
-			...nodes.map(async (node) => {
-				const point = getNodePoint(node);
-				if (!point) {
-					return;
-				}
+// ---------------------------------------------------------------------------
+// In-memory tile cache
+//
+// IndexedDB is the durable store; this is the read path in front of it. Panning
+// around a city re-reads the same handful of tiles over and over, and every one
+// of those reads otherwise costs a structured-clone of a few thousand records
+// out of the database thread. Holding the decoded rows keeps a small pan
+// entirely on the main thread's own heap.
+//
+// Correctness rests on two things: every mutation below updates or drops the
+// affected tiles, and `cacheEpoch` fences reads that were already in flight when
+// a mutation landed so they cannot write what they read back into the cache.
+// ---------------------------------------------------------------------------
 
-				const ref = toRef(node.type ?? 'node', node.id);
-				const existing = (await tx.store.get(ref)) as CachedMapNode | undefined;
-				const deletedFlag = existing?.__deleted ?? (node as CachedMapNode).__deleted ?? false;
+/** Tiles held in memory, in least-recently-used-first order. */
+const tileCache = new Map<string, CachedMapNode[]>();
 
-				const toStore: CachedMapNode = {
-					...(node as CachedMapNode),
-					ref,
-					__deleted: deletedFlag,
-					fetchedAt,
-					lat: point.lat,
-					lon: point.lng
-				};
-				return tx.store.put(toStore);
-			}),
-			tx.done
-		]);
-	} catch (e) {
-		console.error(e);
+/**
+ * Tile budget. A z{@link CACHE_TILE_ZOOM} tile is about a city, so this is
+ * generous for a session's worth of panning while bounding worst-case memory.
+ */
+const MAX_CACHED_TILES = 96;
+
+/**
+ * Bumped by every mutation. A read that started before the bump must not
+ * populate the cache with the rows it saw, because they predate the write.
+ */
+let cacheEpoch = 0;
+
+/**
+ * Resolves once every write handed to {@link trackWrite} has settled.
+ *
+ * Marker writes are deliberately not awaited by the code that renders (see
+ * `markerHandler`'s `updateNodeCache`), so a read issued moments later could
+ * otherwise open its transaction *before* the write opened its own and observe
+ * the pre-write state. Readers await this first, which costs nothing in the
+ * common case where no write is outstanding.
+ */
+let pendingWrites: Promise<void> = Promise.resolve();
+
+function trackWrite(work: Promise<unknown>): Promise<void> {
+	pendingWrites = Promise.allSettled([pendingWrites, work]).then(() => undefined);
+	return pendingWrites;
+}
+
+function evictTiles(): void {
+	while (tileCache.size > MAX_CACHED_TILES) {
+		const oldest = tileCache.keys().next();
+		if (oldest.done) break;
+		tileCache.delete(oldest.value);
 	}
 }
 
-export async function getMapNodesForView(mapBounds: GeoBounds) {
-	try {
-		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
-		const markerStore = transaction.objectStore(markerStoreName);
+/** Drops every cached tile. Used when a mutation's extent isn't worth tracking. */
+function clearTileCache(): void {
+	cacheEpoch++;
+	tileCache.clear();
+}
 
-		// Create an index on lat and lon keys
-		const index = markerStore.index('lat, lon');
+/**
+ * Folds freshly stored rows into the tiles that happen to be resident. Rows for
+ * tiles that aren't cached are ignored — the next read pulls them from
+ * IndexedDB. Refs are removed from every tile first so a node whose position
+ * moved across a tile boundary doesn't linger in its old one.
+ */
+function applyStoredNodesToCache(rows: CachedMapNode[]): void {
+	if (rows.length === 0) return;
+	const refs = new Set(rows.map((row) => row.ref));
+	forgetRefsInCache(refs);
+	for (const row of rows) {
+		const bucket = row.tile ? tileCache.get(row.tile) : undefined;
+		if (bucket) bucket.push(row);
+	}
+	cacheEpoch++;
+}
 
-		// Initialize an empty array to store the results
-		const results: CachedMapNode[] = [];
+/** Removes the given refs from every resident tile. */
+function forgetRefsInCache(refs: Set<OsmRef>): void {
+	for (const [key, rows] of tileCache) {
+		const kept = rows.filter((row) => !refs.has(row.ref));
+		// Replacing an existing key's value leaves Map iteration order untouched,
+		// so mutating while iterating is safe here.
+		if (kept.length !== rows.length) tileCache.set(key, kept);
+	}
+	cacheEpoch++;
+}
 
-		const range = IDBKeyRange.bound(
-			[mapBounds.south, mapBounds.west],
-			[mapBounds.north, mapBounds.east]
-		);
+/** Flags a resident node as soft-deleted without dropping its tile. */
+function markDeletedInCache(ref: OsmRef): void {
+	for (const [key, rows] of tileCache) {
+		const index = rows.findIndex((row) => row.ref === ref);
+		if (index === -1) continue;
+		const updated = rows.slice();
+		updated[index] = { ...updated[index], __deleted: true };
+		tileCache.set(key, updated);
+	}
+	cacheEpoch++;
+}
 
-		let cursor = await index.openCursor(range);
+/** One exact-match index lookup per tile, all inside a single transaction. */
+async function readTilesFromDb(keys: string[]): Promise<Map<string, CachedMapNode[]>> {
+	const tx = (await dbPromise).transaction(markerStoreName, 'readonly');
+	const index = tx.store.index('tile');
+	const batches = await Promise.all(
+		keys.map((key) => index.getAll(key) as Promise<CachedMapNode[]>)
+	);
+	await tx.done;
+	return new Map(keys.map((key, i) => [key, batches[i]]));
+}
 
-		while (cursor) {
-			const mapMarker = cursor.value as CachedMapNode;
+/** Returns every cached node in the given tiles, reading the missing ones. */
+async function getTiles(keys: string[], attempt = 0): Promise<CachedMapNode[]> {
+	const missing = keys.filter((key) => !tileCache.has(key));
+	let fetched: Map<string, CachedMapNode[]> | null = null;
 
-			if (!isDeleted(mapMarker)) {
-				const markerPoint = getNodePoint(mapMarker);
+	if (missing.length > 0) {
+		await pendingWrites;
+		const epoch = cacheEpoch;
+		fetched = await readTilesFromDb(missing);
 
-				if (markerPoint && boundsContains(mapBounds, markerPoint)) {
-					results.push(mapMarker);
-				}
+		if (epoch !== cacheEpoch) {
+			// A write landed mid-read. Retrying is cheap (the tiles it touched are
+			// the ones we want anyway) but must not spin forever under a steady
+			// write load, so fall through and serve what we read after two tries.
+			if (attempt < 2) return getTiles(keys, attempt + 1);
+		} else {
+			for (const [key, rows] of fetched) tileCache.set(key, rows);
+			evictTiles();
+		}
+	}
+
+	const results: CachedMapNode[] = [];
+	for (const key of keys) {
+		const rows = tileCache.get(key);
+		if (rows) {
+			// Touch for LRU: re-inserting moves the key to the end of the Map.
+			tileCache.delete(key);
+			tileCache.set(key, rows);
+			results.push(...rows);
+			continue;
+		}
+		const justRead = fetched?.get(key);
+		if (justRead) results.push(...justRead);
+	}
+	return results;
+}
+
+/**
+ * Upper bound on tiles a single bbox read will enumerate. The map only fetches
+ * markers above zoom 9 and clamps its query span, so real viewports stay far
+ * below this; the cap exists so an unexpectedly wide bbox degrades to one broad
+ * scan instead of thousands of index lookups.
+ */
+const MAX_TILE_QUERY_KEYS = 128;
+
+/**
+ * Every cached node whose tile overlaps `bounds` — a superset of the nodes
+ * actually inside it, since tiles overhang the edges. Callers filter.
+ */
+async function readNodesForBounds(bounds: GeoBounds): Promise<CachedMapNode[]> {
+	const keys = tileKeysForBounds(bounds, CACHE_TILE_ZOOM);
+	if (keys.length > MAX_TILE_QUERY_KEYS) {
+		await pendingWrites;
+		const tx = (await dbPromise).transaction(markerStoreName, 'readonly');
+		const index = tx.store.index('lat, lon');
+		const range = IDBKeyRange.bound([bounds.south, bounds.west], [bounds.north, bounds.east]);
+		const rows = (await index.getAll(range)) as CachedMapNode[];
+		await tx.done;
+		return rows;
+	}
+	return getTiles(keys);
+}
+
+export async function storeMapNodes(nodes: OverPassElement[]) {
+	if (nodes.length === 0) return;
+	const write = (async () => {
+		try {
+			const tx = (await dbPromise).transaction(
+				[markerStoreName, deletedRefsStoreName],
+				'readwrite'
+			);
+			const markers = tx.objectStore(markerStoreName);
+
+			// One request for the whole tombstone set, rather than a `get` per node
+			// just to find out whether this particular one was soft-deleted. Read
+			// inside the same transaction as the writes so a concurrent
+			// `deleteMapNode` can't slip between the two and be overwritten.
+			const tombstones = new Set(
+				(await tx.objectStore(deletedRefsStoreName).getAllKeys()) as OsmRef[]
+			);
+
+			const fetchedAt = Date.now();
+			const stored: CachedMapNode[] = [];
+			const writes: Promise<unknown>[] = [];
+
+			for (const node of nodes) {
+				const point = getNodePoint(node);
+				if (!point) continue;
+
+				const ref = toRef(node.type ?? 'node', node.id);
+				const toStore: CachedMapNode = {
+					...(node as CachedMapNode),
+					ref,
+					__deleted: tombstones.has(ref) || Boolean((node as CachedMapNode).__deleted),
+					fetchedAt,
+					lat: point.lat,
+					lon: point.lng,
+					tile: tileKey(lngLatToTile(point.lat, point.lng, CACHE_TILE_ZOOM))
+				};
+				stored.push(toStore);
+				writes.push(markers.put(toStore));
 			}
 
-			cursor = await cursor.continue();
+			await Promise.all([...writes, tx.done]);
+			applyStoredNodesToCache(stored);
+		} catch (e) {
+			console.error(e);
+			// The cache may hold rows this write was meant to replace; drop it
+			// rather than serve a half-applied view.
+			clearTileCache();
 		}
-		return results;
+	})();
+
+	await trackWrite(write);
+}
+
+export async function getMapNodesForView(mapBounds: GeoBounds): Promise<CachedMapNode[]> {
+	try {
+		const candidates = await readNodesForBounds(mapBounds);
+		return candidates.filter((node) => {
+			if (isDeleted(node)) return false;
+			const point = getNodePoint(node);
+			return point !== null && boundsContains(mapBounds, point);
+		});
 	} catch (e) {
 		console.error(e);
 		return [];
@@ -286,37 +555,24 @@ export async function getMapNodesForView(mapBounds: GeoBounds) {
 
 export async function getNearbyMapNodes(location: GeoPoint, radius: number) {
 	try {
-		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
-		const markerStore = transaction.objectStore(markerStoreName);
-
 		const latDelta = radius / 111000;
 		const lngDelta = radius / (111000 * Math.cos((location.lat * Math.PI) / 180));
+		const bounds: GeoBounds = {
+			south: location.lat - latDelta,
+			north: location.lat + latDelta,
+			west: location.lng - lngDelta,
+			east: location.lng + lngDelta
+		};
 
-		const index = markerStore.index('lat, lon');
-		const range = IDBKeyRange.bound(
-			[location.lat - latDelta, location.lng - lngDelta],
-			[location.lat + latDelta, location.lng + lngDelta]
-		);
-
+		const candidates = await readNodesForBounds(bounds);
 		const results: OverPassElement[] = [];
-		let cursor = await index.openCursor(range);
 
-		while (cursor) {
-			const mapMarker = cursor.value as CachedMapNode;
-
-			if (!isDeleted(mapMarker)) {
-				const markerPoint = getNodePoint(mapMarker);
-
-				if (markerPoint) {
-					const distance = distanceTo(location, markerPoint);
-
-					if (distance <= radius) {
-						results.push(mapMarker);
-					}
-				}
+		for (const node of candidates) {
+			if (isDeleted(node)) continue;
+			const point = getNodePoint(node);
+			if (point && distanceTo(location, point) <= radius) {
+				results.push(node);
 			}
-
-			cursor = await cursor.continue();
 		}
 
 		return results;
@@ -351,27 +607,16 @@ export interface CachedNodeRef {
 
 export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<CachedNodeRef[]> {
 	try {
-		const transaction = (await dbPromise).transaction(markerStoreName, 'readonly');
-		const markerStore = transaction.objectStore(markerStoreName);
-		const index = markerStore.index('lat, lon');
-
-		const range = IDBKeyRange.bound(
-			[mapBounds.south, mapBounds.west],
-			[mapBounds.north, mapBounds.east]
-		);
-
+		const candidates = await readNodesForBounds(mapBounds);
 		const refs: CachedNodeRef[] = [];
-		let cursor = await index.openCursor(range);
 
-		while (cursor) {
-			const mapMarker = cursor.value as CachedMapNode;
-			const markerPoint = getNodePoint(mapMarker);
-
-			if (markerPoint && boundsContains(mapBounds, markerPoint)) {
-				refs.push({ ref: mapMarker.ref, fetchedAt: mapMarker.fetchedAt ?? 0 });
+		for (const node of candidates) {
+			// Soft-deleted rows are deliberately included: reconciliation is what
+			// eventually collects them once the source agrees they are gone.
+			const point = getNodePoint(node);
+			if (point && boundsContains(mapBounds, point)) {
+				refs.push({ ref: node.ref, fetchedAt: node.fetchedAt ?? 0 });
 			}
-
-			cursor = await cursor.continue();
 		}
 
 		return refs;
@@ -383,12 +628,21 @@ export async function getMapNodeRefsForBounds(mapBounds: GeoBounds): Promise<Cac
 
 export async function hardDeleteMapNodes(refs: OsmRef[]) {
 	if (!refs.length) return;
-	try {
-		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
-		await Promise.all([...refs.map((ref) => tx.store.delete(ref)), tx.done]);
-	} catch (e) {
-		console.error('Error hard-deleting map nodes:', e);
-	}
+	const write = (async () => {
+		try {
+			const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
+			await Promise.all([...refs.map((ref) => tx.store.delete(ref)), tx.done]);
+			// Surgical rather than a full clear: this runs after every viewport
+			// fetch, and dropping all resident tiles each time would undo the
+			// in-memory cache entirely.
+			forgetRefsInCache(new Set(refs));
+		} catch (e) {
+			console.error('Error hard-deleting map nodes:', e);
+			clearTileCache();
+		}
+	})();
+
+	await trackWrite(write);
 }
 
 /**
@@ -398,6 +652,9 @@ export async function hardDeleteMapNodes(refs: OsmRef[]) {
  * without a timestamp) is treated as stale. Iterates the `fetchedAt` index so
  * only stale rows are visited.
  */
+/** Nodes deleted per prune transaction — see {@link pruneStaleMapNodes}. */
+const PRUNE_BATCH_SIZE = 500;
+
 export async function pruneStaleMapNodes(maxAgeMs: number) {
 	try {
 		// Nodes inside a downloaded offline area must never be pruned, even when
@@ -405,45 +662,79 @@ export async function pruneStaleMapNodes(maxAgeMs: number) {
 		// Membership is a pure bounds check, so we load the areas once per run.
 		const areas = await getAllOfflineAreas();
 		const isProtected = (node: CachedMapNode): boolean => {
-			if (areas.length === 0) return false;
 			const point = getNodePoint(node);
 			return point !== null && areas.some((area) => boundsContains(area.bounds, point));
 		};
 
 		const cutoff = Date.now() - maxAgeMs;
-		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
-		const index = tx.store.index('fetchedAt');
+		const db = await dbPromise;
 
+		// Phase 1 — decide what goes, under a *readonly* transaction. The previous
+		// implementation cursor-deleted inside one long readwrite transaction,
+		// which holds an exclusive lock on the marker store: every viewport read
+		// issued while it ran queued behind it. Since this is kicked off at
+		// startup, that lock sat directly in front of the first map render.
+		const readTx = db.transaction(markerStoreName, 'readonly');
+		const index = readTx.store.index('fetchedAt');
 		// upperBound(cutoff, true) → strictly `fetchedAt < cutoff`.
-		let cursor = await index.openCursor(IDBKeyRange.upperBound(cutoff, true));
-		while (cursor) {
-			if (!isProtected(cursor.value as CachedMapNode)) {
-				await cursor.delete();
-			}
-			cursor = await cursor.continue();
+		const range = IDBKeyRange.upperBound(cutoff, true);
+		// With no offline areas nothing can be protected, so the coordinates are
+		// never needed and the keys alone are far cheaper to materialize.
+		const doomed: OsmRef[] =
+			areas.length === 0
+				? ((await index.getAllKeys(range)) as OsmRef[])
+				: ((await index.getAll(range)) as CachedMapNode[])
+						.filter((node) => !isProtected(node))
+						.map((node) => node.ref);
+		await readTx.done;
+
+		if (doomed.length === 0) return;
+
+		// Phase 2 — delete in bounded batches, each its own short transaction, so
+		// a read never waits on more than one batch.
+		for (let i = 0; i < doomed.length; i += PRUNE_BATCH_SIZE) {
+			const batch = doomed.slice(i, i + PRUNE_BATCH_SIZE);
+			const tx = db.transaction(markerStoreName, 'readwrite');
+			await Promise.all([...batch.map((ref) => tx.store.delete(ref)), tx.done]);
 		}
 
-		await tx.done;
+		clearTileCache();
 	} catch (e) {
 		console.error('Error pruning stale map nodes:', e);
+		clearTileCache();
 	}
 }
 
 export async function deleteMapNode(ref: OsmRef) {
-	try {
-		const tx = (await dbPromise).transaction(markerStoreName, 'readwrite');
+	const write = (async () => {
+		try {
+			const tx = (await dbPromise).transaction(
+				[markerStoreName, deletedRefsStoreName],
+				'readwrite'
+			);
+			const markers = tx.objectStore(markerStoreName);
 
-		// Soft-delete: keep the record in the cache, but mark it as deleted.
-		const existing = (await tx.store.get(ref)) as CachedMapNode | undefined;
+			// The tombstone is the authoritative record — it is what keeps a later
+			// `storeMapNodes` from resurrecting the node when the extract, which is
+			// days behind OSM, still lists it. The flag on the row is a mirror so
+			// readers don't have to join the two stores.
+			const existing = (await markers.get(ref)) as CachedMapNode | undefined;
+			const writes: Promise<unknown>[] = [
+				tx.objectStore(deletedRefsStoreName).put({ ref, deletedAt: Date.now() } as DeletedRefRecord)
+			];
+			if (existing) {
+				writes.push(markers.put({ ...existing, __deleted: true }));
+			}
 
-		if (existing) {
-			await tx.store.put({ ...existing, __deleted: true });
+			await Promise.all([...writes, tx.done]);
+			markDeletedInCache(ref);
+		} catch (e) {
+			console.error(e);
+			clearTileCache();
 		}
+	})();
 
-		await tx.done;
-	} catch (e) {
-		console.error(e);
-	}
+	await trackWrite(write);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -201,13 +201,20 @@ let liveRefreshInFlight = false;
 
 /**
  * Everything about an element that the marker layer actually draws: which
- * object it is and which icon it gets. Two elements with the same signature
- * produce the same feature, so a live refresh that only returns those has
- * nothing to re-render — tag edits that don't move the icon are picked up by
- * the info panel, which reads the node itself.
+ * object it is, which icon it gets and where it sits. Two elements with the
+ * same signature produce the same feature, so a live refresh that only returns
+ * those has nothing to re-render — tag edits that change neither the icon nor
+ * the position are picked up by the info panel, which reads the node itself.
+ *
+ * The position has to be in here: a node that was moved in OSM keeps its ref
+ * and its icon, so without it the refresh would decide nothing changed and
+ * leave the marker at its old coordinates until the next pan. Rounded to ~1 cm
+ * so float noise can't force a pointless re-render.
  */
 function renderSignature(element: OverPassElement): string {
-	return `${toRef(element.type, element.id)}:${getIconKeyForNode(element)}`;
+	const lat = (element.lat ?? element.center?.lat ?? 0).toFixed(7);
+	const lng = (element.lon ?? element.center?.lon ?? 0).toFixed(7);
+	return `${toRef(element.type, element.id)}:${getIconKeyForNode(element)}:${lat},${lng}`;
 }
 
 /** True when every given tile was asked of Overpass within the live TTL. */

--- a/src/mapHandler/markerHandler.ts
+++ b/src/mapHandler/markerHandler.ts
@@ -23,7 +23,7 @@ import { useMapMarkerStore } from '@/store/mapMarkerStore';
 import { useSettingsStore, type MarkerFilterKey } from '@/store/settingsStore';
 import { NearbyMarker } from '@/composable/nearbyWaterSource';
 import { computeNearbyDistances, NearbyDistanceResult } from '@/mapHandler/nearbyRouting';
-import { lngLatToTile, tileKey } from '@/helper/tileMath';
+import { tileKeysForBounds } from '@/helper/tileMath';
 import { OsmRef, toRef } from '@/helper/osmRef';
 
 // Map icon keys to URLs for use in MapLibre image loading
@@ -119,15 +119,7 @@ function padBounds(bounds: GeoBounds, ratio: number): GeoBounds {
 
 /** All z{@link FRESHNESS_ZOOM} tile keys covering the given bounds. */
 function coveringTileKeys(bounds: GeoBounds): string[] {
-	const nw = lngLatToTile(bounds.north, bounds.west, FRESHNESS_ZOOM);
-	const se = lngLatToTile(bounds.south, bounds.east, FRESHNESS_ZOOM);
-	const keys: string[] = [];
-	for (let x = nw.x; x <= se.x; x++) {
-		for (let y = nw.y; y <= se.y; y++) {
-			keys.push(tileKey({ z: FRESHNESS_ZOOM, x, y }));
-		}
-	}
-	return keys;
+	return tileKeysForBounds(bounds, FRESHNESS_ZOOM);
 }
 
 /** True when every given tile was fetched within the freshness TTL. */
@@ -207,6 +199,17 @@ const LIVE_FRESHNESS_TTL_MS = 5 * 60 * 1000;
 
 let liveRefreshInFlight = false;
 
+/**
+ * Everything about an element that the marker layer actually draws: which
+ * object it is and which icon it gets. Two elements with the same signature
+ * produce the same feature, so a live refresh that only returns those has
+ * nothing to re-render — tag edits that don't move the icon are picked up by
+ * the info panel, which reads the node itself.
+ */
+function renderSignature(element: OverPassElement): string {
+	return `${toRef(element.type, element.id)}:${getIconKeyForNode(element)}`;
+}
+
 /** True when every given tile was asked of Overpass within the live TTL. */
 function areTilesLiveFresh(keys: string[]): boolean {
 	const now = Date.now();
@@ -259,10 +262,19 @@ async function refreshFromLiveSource(mapBounds: GeoBounds): Promise<void> {
 
 		if (liveElements.length === 0) return;
 
+		// Decide whether this changes anything *on screen* before storing, while
+		// the cached rows still describe what is currently rendered. Overpass is
+		// asked on every move into a new area, and in the overwhelmingly common
+		// case it just confirms the extract — bumping the cache version regardless
+		// would then cost a full re-read, GeoJSON rebuild and supercluster
+		// re-index for a frame identical to the one already on screen.
+		const rendered = new Set((await getMapNodesForView(queryBounds)).map(renderSignature));
+		const changed = liveElements.some((element) => !rendered.has(renderSignature(element)));
+
 		// Upsert only. storeMapNodes keys by ref and overwrites, so anything
 		// Overpass knows about more recently than the extract wins.
 		await storeMapNodes(liveElements);
-		markerCacheVersion.value++;
+		if (changed) markerCacheVersion.value++;
 	} catch {
 		// Silent by design — the static layer already rendered.
 	} finally {
@@ -270,7 +282,76 @@ async function refreshFromLiveSource(mapBounds: GeoBounds): Promise<void> {
 	}
 }
 
-async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]> {
+/** True for the `AbortError` a superseded or cancelled fetch rejects with. */
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException && error.name === 'AbortError';
+}
+
+/**
+ * Writes a completed fetch into the cache: store, then reconcile deletions.
+ *
+ * Deliberately **not** awaited by the render path. Storing a thousand nodes and
+ * then reconciling them is a few thousand IndexedDB requests, and none of it is
+ * something the user has to wait to see — the elements needed to draw the
+ * viewport are already in hand the moment the fetch resolves. Keeping this in
+ * front of the first paint was what made moving into a new city feel slow.
+ *
+ * `databaseHandler` fences its own reads behind these writes, so a viewport read
+ * issued while this is still running cannot observe the pre-write state.
+ */
+async function persistFetchedNodes(
+	queryBounds: GeoBounds,
+	elements: OverPassElement[],
+	notify: boolean
+): Promise<void> {
+	try {
+		await storeMapNodes(elements);
+
+		// An FGB range read is never truncated the way Overpass's 2000-element
+		// response could be, so — unlike the old Overpass path — reconciliation
+		// always sees the complete set of features the extract holds for
+		// `queryBounds`, and needs no element-count guard.
+		//
+		// It does need a staleness guard instead: the extract is rebuilt only every
+		// couple of days, so it cannot know about anything mapped since it was cut.
+		// Reconciling against its planet timestamp keeps those newer nodes — most
+		// importantly the user's own just-added markers. If the timestamp can't be
+		// determined (metadata unreachable) we skip reconciliation entirely rather
+		// than risk deleting live data; stale nodes are handled by the TTL prune.
+		//
+		// This lookup is also why the reconcile must not block rendering: on the
+		// first fetch of a session it is an uncached network round-trip to
+		// `metadata.json`, sitting between the user and their markers.
+		const extractTimestampMs = await getExtractTimestampMs();
+		if (extractTimestampMs !== null) {
+			await reconcileDeletedNodes(queryBounds, elements, extractTimestampMs);
+		}
+	} catch (e) {
+		console.error('Persisting fetched water sources failed:', e);
+	} finally {
+		// Signal that the cache changed so the map re-renders with the freshly
+		// fetched markers. Only the silent background refresh needs this: its
+		// caller already returned the (stale) cached features, so without the bump
+		// the new data wouldn't appear until the next pan. The foreground path
+		// renders the fetched elements itself and passes `notify: false`, since a
+		// bump there would only buy a second, identical render.
+		if (notify) markerCacheVersion.value++;
+	}
+}
+
+interface NodeCacheUpdate {
+	/** The freshly fetched elements, ready to render. Empty on failure. */
+	elements: OverPassElement[];
+	/** Resolves once {@link persistFetchedNodes} has finished. */
+	persisted: Promise<void>;
+	/** The fetch was cancelled rather than attempted — see {@link isAbortError}. */
+	aborted: boolean;
+}
+
+async function updateNodeCache(
+	mapBounds: GeoBounds,
+	options: { notify: boolean; signal?: AbortSignal }
+): Promise<NodeCacheUpdate> {
 	// Pad the query bbox so small subsequent pans stay inside the fetched area,
 	// then apply the same span clamp as the actual query. Freshness stamps and
 	// stale-node reconciliation below must only ever cover the area that was
@@ -281,16 +362,23 @@ async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]>
 	activeAreaFetches.value++;
 	let mapElements: OverPassElement[];
 	try {
-		mapElements = await fetchWaterSources(queryBounds);
+		mapElements = await fetchWaterSources(queryBounds, options.signal);
 		lastStaticQueryFailed = false;
 	} catch (e) {
 		// Unlike fetchMarkerData, fetchWaterSources throws rather than returning
 		// null on failure. Leave the cache untouched — no fresh-tile stamping, no
 		// reconciliation — so a transient outage never looks like "everything in
 		// this area was deleted".
+		if (isAbortError(e)) {
+			// The user panned away; this view is nobody's concern any more. Not a
+			// failure, so `lastStaticQueryFailed` is left exactly as it was — and
+			// the tiles stay unstamped, so the area is fetched again if it is next
+			// looked at.
+			return { elements: [], persisted: Promise.resolve(), aborted: true };
+		}
 		console.error('Static water-source fetch failed:', e);
 		lastStaticQueryFailed = true;
-		return [];
+		return { elements: [], persisted: Promise.resolve(), aborted: false };
 	} finally {
 		activeAreaFetches.value--;
 	}
@@ -299,29 +387,11 @@ async function updateNodeCache(mapBounds: GeoBounds): Promise<OverPassElement[]>
 	// skip its background refresh.
 	markTilesFresh(coveringTileKeys(queryBounds));
 
-	await storeMapNodes(mapElements);
-	// An FGB range read is never truncated the way Overpass's 2000-element
-	// response could be, so — unlike the old Overpass path — reconciliation
-	// always sees the complete set of features the extract holds for
-	// `queryBounds`, and needs no element-count guard.
-	//
-	// It does need a staleness guard instead: the extract is rebuilt only every
-	// couple of days, so it cannot know about anything mapped since it was cut.
-	// Reconciling against its planet timestamp keeps those newer nodes — most
-	// importantly the user's own just-added markers. If the timestamp can't be
-	// determined (metadata unreachable) we skip reconciliation entirely rather
-	// than risk deleting live data; stale nodes are handled by the TTL prune.
-	const extractTimestampMs = await getExtractTimestampMs();
-	if (extractTimestampMs !== null) {
-		await reconcileDeletedNodes(queryBounds, mapElements, extractTimestampMs);
-	}
-
-	// Signal that the cache changed so the map re-renders with the freshly
-	// fetched markers. Crucial for the silent background refresh path: its caller
-	// already returned the (stale) cached features, so without this bump the new
-	// data wouldn't appear until the next pan.
-	markerCacheVersion.value++;
-	return mapElements;
+	return {
+		elements: mapElements,
+		persisted: persistFetchedNodes(queryBounds, mapElements, options.notify),
+		aborted: false
+	};
 }
 
 /**
@@ -358,7 +428,20 @@ let backgroundRefreshInFlight = false;
  */
 export const markerFetchFailed = ref(false);
 
-export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.FeatureCollection> {
+/**
+ * Builds the marker layer's GeoJSON for `mapBounds`, fetching the area first if
+ * nothing is cached for it.
+ *
+ * Pass `signal` to cancel a fetch that a newer map movement has superseded: the
+ * in-flight range requests are aborted rather than left to download a viewport
+ * nobody is looking at any more. A cancelled fetch is not treated as a failure
+ * and leaves no freshness stamp, so the area is simply fetched again if the user
+ * comes back to it.
+ */
+export async function getMarkersForView(
+	mapBounds: GeoBounds,
+	signal?: AbortSignal
+): Promise<GeoJSON.FeatureCollection> {
 	const features: GeoJSON.Feature[] = [];
 	try {
 		let mapElements: OverPassElement[] = await getMapNodesForView(mapBounds);
@@ -377,8 +460,15 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 			// Nothing cached for this view. Fetch only if we haven't already
 			// covered this area within the freshness TTL.
 			if (!tilesFresh) {
-				mapElements = await updateNodeCache(mapBounds);
-				markerFetchFailed.value = lastStaticQueryFailed;
+				// `notify: false` — the fetched elements are rendered below, so the
+				// cache-version bump would only trigger an identical second render.
+				// The write itself is not awaited: markers appear as soon as the
+				// network read lands, and persistence catches up behind them.
+				const update = await updateNodeCache(mapBounds, { notify: false, signal });
+				mapElements = update.elements;
+				// A cancelled fetch says nothing about whether the data source is
+				// reachable, so it must not raise *or* clear the error banner.
+				if (!update.aborted) markerFetchFailed.value = lastStaticQueryFailed;
 			}
 		} else {
 			// Cache hit: this view renders real data, so a failure recorded for a
@@ -396,12 +486,22 @@ export async function getMarkersForView(mapBounds: GeoBounds): Promise<GeoJSON.F
 				// abort errors (superseded by a newer request) and network failures.
 				// Background failures while cached data is already on screen are
 				// intentionally not surfaced (markerFetchFailed stays unchanged).
+				//
+				// Deliberately not given `signal`: nothing is waiting on this render,
+				// so letting it finish keeps the cache warm for when the user pans
+				// back. The in-flight guard is held until the *write* completes, not
+				// just the fetch, so a burst of pans can't stack overlapping stores.
 				backgroundRefreshInFlight = true;
-				updateNodeCache(mapBounds)
-					.catch(() => {})
-					.finally(() => {
+				void (async () => {
+					try {
+						const update = await updateNodeCache(mapBounds, { notify: true });
+						await update.persisted;
+					} catch {
+						// Silent by design — cached data is already on screen.
+					} finally {
 						backgroundRefreshInFlight = false;
-					});
+					}
+				})();
 			}
 		}
 


### PR DESCRIPTION
Viewport reads were answered by walking a cursor over the compound
`['lat','lon']` index with `IDBKeyRange.bound([south,west],[north,east])`.
That range is lexicographic, not a 2D box: it matches every row whose
latitude falls in the band, at any longitude on the planet, and the
longitude filter only ran afterwards in JS. Read cost therefore scaled
with the whole cache at that latitude rather than with the viewport, so
the map got slower the more the user had panned around. Each row also
cost its own `cursor.continue()` round-trip.

DB v5 files every node under a z10 slippy-tile key with its own index, so
a viewport read is a handful of exact-match `getAll` lookups. A bounded
LRU of decoded tiles sits in front of that, so panning inside an area the
user is already looking at never reaches IndexedDB at all. Bounds too
wide to enumerate as tiles still fall back to the `lat, lon` index, which
is kept for exactly that reason.

Writes drop from two requests per node to one: soft-delete tombstones
move into their own `deletedRefs` store, so `storeMapNodes` reads the
whole tombstone set once instead of `get`ting every row it is about to
overwrite. Tombstones still win over an extract that has not caught up.

The startup prune no longer cursor-deletes inside one long `readwrite`
transaction. That transaction holds an exclusive lock on the marker
store, and the map mounts at the same moment and immediately reads it, so
the first viewport read queued behind the whole prune. It now selects
under a readonly transaction, deletes in bounded batches, and is deferred
to idle.

Measured in headless Chromium on a 20 800-row cache with 800 nodes in
view: 563 ms for the old cursor walk (19 468 rows visited) against 27 ms
for a cold tile read and 0.3 ms warm, returning identical result sets.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VLRd7nLX3gs39JEzHbvwpY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved map responsiveness by moving cache maintenance to idle time.
  - Added tile-based caching to speed up viewport, nearby, and bounds-based marker loading.
  - Optimized cache pruning, background refreshes, and cache updates.

- **Bug Fixes**
  - Prevented outdated requests from overwriting newer marker results during rapid map movement.
  - Reduced unnecessary refreshes when visible markers have not changed.
  - Improved map coverage across areas crossing the international date line.
  - Preserved deleted-marker state during cache updates and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->