### PR TITLE
docs: add the missing What's New entry and a CLAUDE.md pointer to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+This project's guidance for AI agents lives in **[AGENTS.md](./AGENTS.md)** —
+a single file shared by every assistant that works on FireYak, so the rules
+never drift apart between tools.
+
+**Read `AGENTS.md` before making changes.** It covers the project overview,
+tech stack, directory and store layout, key commands, architectural patterns,
+and the repo's hard requirements — including §6, which makes a
+`src/assets/whats-new.json` entry mandatory for every user-facing change, and
+§7's note that there is no test suite.
+
+Put new agent guidance in `AGENTS.md`, not here. This file exists only to point
+at it.

--- a/src/assets/whats-new.json
+++ b/src/assets/whats-new.json
@@ -4,6 +4,11 @@
 			"type": "feature",
 			"en": "Photos of a water source can now also come from Panoramax, each labelled with its source and linked to the original.",
 			"de": "Fotos einer Wasserentnahmestelle können jetzt auch von Panoramax stammen – mit Quellenangabe und Link zum Original."
+		},
+		{
+			"type": "improvement",
+			"en": "Water sources now appear as soon as the map reaches a new area, instead of after a noticeable wait.",
+			"de": "Wasserentnahmestellen erscheinen jetzt direkt beim Wechsel in ein neues Gebiet – ohne spürbare Wartezeit."
 		}
 	],
 	"releases": [


### PR DESCRIPTION
## Summary

Adds the `whats-new.json` entry that #98 should have carried — AGENTS.md §6 makes one mandatory for every user-facing change, and "markers appear right after you move the map" is exactly that. Also adds a `CLAUDE.md` that redirects to `AGENTS.md`, which is how §6 got missed in the first place: Claude Code looks for `CLAUDE.md` by default, and the repo only had `AGENTS.md`.

## Type of change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 🧹 Refactoring / chore (no user-facing change)
- [x] 📖 Documentation

## How was it tested?

- [ ] Web (`npm run dev` / built bundle)
- [ ] Android (device or emulator)
- [ ] iOS (device or simulator)
- [x] Not applicable (docs/CI only)

`npm run build` and `npx eslint .` both pass, and `whats-new.json` parses with the new entry in `unreleased`. There is nothing to observe in the running app yet: `whatsNew.ts` reads only the `releases` array, so the entry becomes visible once `stamp-whats-new.mjs` moves it across at release time.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run build` and lint pass locally
- [ ] New user-facing strings added to **both** `src/locales/en.json` and `src/locales/de.json` — n/a, no locale strings change; the entry carries its own `en`/`de`
- [x] What's New entry added to `src/assets/whats-new.json` (en + de) for user-facing changes — see `AGENTS.md` §6 for the format

- [x] No secrets, API keys, or personal data in the diff
- [ ] Screenshots attached for UI changes — n/a, no UI change

## Notes

**The entry** — appended to `unreleased` only, `releases` untouched:

```json
{ "type": "improvement",
  "en": "Water sources now appear as soon as the map reaches a new area, instead of after a noticeable wait.",
  "de": "Wasserentnahmestellen erscheinen jetzt direkt beim Wechsel in ein neues Gebiet – ohne spürbare Wartezeit." }
```

Worded to stay distinct from the 2.17.0 entry ("load reliably and much faster, even at peak times"): that one was about the data source being slow, this one is about the delay after moving the map. No jargon, both under ~120 characters.

**CLAUDE.md** is a pointer rather than a copy. Duplicating the guidance would let the two files drift, and the value of `AGENTS.md` is that every assistant reads the same rules. It calls out §6 and §7 by name so they are hard to skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLRd7nLX3gs39JEzHbvwpY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Water sources now appear immediately when entering a new map area.
  * Reduced noticeable loading delays for a smoother experience.

* **Documentation**
  * Updated release notes in English and German to reflect the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->